### PR TITLE
store: fix RFC 8621 thread resolution via References header (migration 0041)

### DIFF
--- a/internal/diag/backup/adapter_sqlite.go
+++ b/internal/diag/backup/adapter_sqlite.go
@@ -314,14 +314,14 @@ func (s *sqliteSource) EnumerateRows(ctx context.Context, table string, fn func(
 			`SELECT id, principal_id, internal_date_us, received_at_us, size,
 			        blob_hash, blob_size, thread_id, env_subject, env_from,
 			        env_to, env_cc, env_bcc, env_reply_to, env_message_id,
-			        env_in_reply_to, env_date_us
+			        env_in_reply_to, env_references, env_date_us
 			   FROM messages ORDER BY id`,
 			func(rs *sql.Rows) (any, error) {
 				var r MessageRow
 				if err := rs.Scan(&r.ID, &r.PrincipalID, &r.InternalDateUs, &r.ReceivedAtUs,
 					&r.Size, &r.BlobHash, &r.BlobSize, &r.ThreadID,
 					&r.EnvSubject, &r.EnvFrom, &r.EnvTo, &r.EnvCc, &r.EnvBcc,
-					&r.EnvReplyTo, &r.EnvMessageID, &r.EnvInReplyTo, &r.EnvDateUs); err != nil {
+					&r.EnvReplyTo, &r.EnvMessageID, &r.EnvInReplyTo, &r.EnvReferences, &r.EnvDateUs); err != nil {
 					return nil, err
 				}
 				return &r, nil
@@ -1212,12 +1212,13 @@ func (s *sqliteSink) Insert(ctx context.Context, table string, row any) error {
 		_, err := s.tx.ExecContext(ctx,
 			`INSERT INTO messages (id, principal_id, internal_date_us, received_at_us,
 			   size, blob_hash, blob_size, thread_id, env_subject, env_from, env_to,
-			   env_cc, env_bcc, env_reply_to, env_message_id, env_in_reply_to, env_date_us)
-			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			   env_cc, env_bcc, env_reply_to, env_message_id, env_in_reply_to,
+			   env_references, env_date_us)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			r.ID, r.PrincipalID, r.InternalDateUs, r.ReceivedAtUs,
 			r.Size, r.BlobHash, r.BlobSize, r.ThreadID,
 			r.EnvSubject, r.EnvFrom, r.EnvTo, r.EnvCc, r.EnvBcc, r.EnvReplyTo,
-			r.EnvMessageID, r.EnvInReplyTo, r.EnvDateUs)
+			r.EnvMessageID, r.EnvInReplyTo, r.EnvReferences, r.EnvDateUs)
 		return err
 	case "message_mailboxes":
 		r := row.(*MessageMailboxRow)

--- a/internal/diag/backup/manifest.go
+++ b/internal/diag/backup/manifest.go
@@ -186,7 +186,17 @@ const CurrentBackupVersion = 1
 //	with ON DELETE CASCADE from messages(id). The server snapshots
 //	non-Trash memberships when a message gains a Trash membership and
 //	replays them on Restore, then clears the snapshot.
-const CurrentSchemaVersion = 40
+//
+// 41 — 0041_messages_env_references.sql. Column-only migration: adds
+//
+//	messages.env_references TEXT NOT NULL DEFAULT '' to store the raw
+//	References header value. InsertMessage now uses both InReplyTo and
+//	References for thread resolution so RFC 8621 sec 8.1 threading
+//	(union of all ancestor message-ids) works correctly. Fixes
+//	Thread/get returning fragmented threads and the downstream failures
+//	in someInThreadHaveKeyword, noneInThreadHaveKeyword, and
+//	collapseThreads. No new tables.
+const CurrentSchemaVersion = 41
 
 // Manifest is the metadata block written to <bundle>/manifest.json. It
 // summarises the backup so operators (and the verify subcommand) can

--- a/internal/diag/backup/rows.go
+++ b/internal/diag/backup/rows.go
@@ -171,6 +171,7 @@ type MessageRow struct {
 	EnvReplyTo     string `json:"env_reply_to"`
 	EnvMessageID   string `json:"env_message_id"`
 	EnvInReplyTo   string `json:"env_in_reply_to"`
+	EnvReferences  string `json:"env_references"`
 	EnvDateUs      int64  `json:"env_date_us"`
 }
 

--- a/internal/protoimap/session_mailbox.go
+++ b/internal/protoimap/session_mailbox.go
@@ -868,14 +868,15 @@ func parseEnvelope(raw []byte) store.Envelope {
 		return store.Envelope{}
 	}
 	env := store.Envelope{
-		Subject:   msg.Header.Get("Subject"),
-		From:      msg.Header.Get("From"),
-		To:        msg.Header.Get("To"),
-		Cc:        msg.Header.Get("Cc"),
-		Bcc:       msg.Header.Get("Bcc"),
-		ReplyTo:   msg.Header.Get("Reply-To"),
-		MessageID: strings.Trim(msg.Header.Get("Message-ID"), "<>"),
-		InReplyTo: strings.Trim(msg.Header.Get("In-Reply-To"), "<>"),
+		Subject:    msg.Header.Get("Subject"),
+		From:       msg.Header.Get("From"),
+		To:         msg.Header.Get("To"),
+		Cc:         msg.Header.Get("Cc"),
+		Bcc:        msg.Header.Get("Bcc"),
+		ReplyTo:    msg.Header.Get("Reply-To"),
+		MessageID:  strings.Trim(msg.Header.Get("Message-ID"), "<>"),
+		InReplyTo:  strings.Trim(msg.Header.Get("In-Reply-To"), "<>"),
+		References: msg.Header.Get("References"),
 	}
 	if ds := msg.Header.Get("Date"); ds != "" {
 		if t, err := mail.ParseDate(ds); err == nil {

--- a/internal/protojmap/mail/email/envelope.go
+++ b/internal/protojmap/mail/email/envelope.go
@@ -26,6 +26,17 @@ func buildEnvelopeFromParsed(m mailparse.Message) store.Envelope {
 	if len(m.Envelope.InReplyTo) > 0 {
 		env.InReplyTo = m.Envelope.InReplyTo[0]
 	}
+	// Store the raw References value so InsertMessage can use it for
+	// thread resolution via mailparse.ParseReferences. We re-bracket the
+	// already-normalized IDs because ParseReferences expects angle-bracket
+	// tokens.
+	if len(m.Envelope.References) > 0 {
+		parts := make([]string, len(m.Envelope.References))
+		for i, r := range m.Envelope.References {
+			parts[i] = "<" + r + ">"
+		}
+		env.References = strings.Join(parts, " ")
+	}
 	if m.Envelope.Date != "" {
 		if t, err := mail.ParseDate(m.Envelope.Date); err == nil {
 			env.Date = t.UTC()

--- a/internal/protojmap/mail/email/import.go
+++ b/internal/protojmap/mail/email/import.go
@@ -118,9 +118,14 @@ func (i *importHandler) Execute(ctx context.Context, args json.RawMessage) (any,
 }
 
 // relinkThreads walks createdIDs and, for each message whose InReplyTo
-// points to an ancestor that now exists in the store, updates the
-// thread_id to match the ancestor's thread. This fixes threading when
-// replies are imported before their originals.
+// or References points to an ancestor that now exists in the store,
+// updates the thread_id to match the ancestor's thread. This fixes
+// threading when replies are imported before their originals.
+//
+// We check both In-Reply-To and References (RFC 5256 sec 2.2) so that
+// messages that reference an ancestor only via References (common when
+// three or more messages form a chain and intermediate messages are
+// absent) still land in the same thread.
 func (i *importHandler) relinkThreads(ctx context.Context, pid store.PrincipalID, createdIDs []store.MessageID) error {
 	if len(createdIDs) == 0 {
 		return nil
@@ -130,14 +135,24 @@ func (i *importHandler) relinkThreads(ctx context.Context, pid store.PrincipalID
 		if err != nil {
 			continue // silently skip; best-effort
 		}
-		if msg.Envelope.InReplyTo == "" {
+		if msg.Envelope.InReplyTo == "" && msg.Envelope.References == "" {
 			continue
 		}
 		if msg.ThreadID != 0 && msg.ThreadID != uint64(msg.ID) {
 			continue // already properly threaded (ancestor was present at import time)
 		}
-		// Look up the ancestor by Message-ID.
+		// Union InReplyTo and References, InReplyTo first.
 		refs := mailparse.ParseReferences(msg.Envelope.InReplyTo)
+		seen := make(map[string]struct{}, len(refs))
+		for _, r := range refs {
+			seen[r] = struct{}{}
+		}
+		for _, r := range mailparse.ParseReferences(msg.Envelope.References) {
+			if _, dup := seen[r]; !dup {
+				refs = append(refs, r)
+				seen[r] = struct{}{}
+			}
+		}
 		for _, ref := range refs {
 			ancestor, err := i.h.store.Meta().GetMessageByMessageIDHeader(ctx, pid, ref)
 			if err != nil {

--- a/internal/protojmap/mail/thread/methods.go
+++ b/internal/protojmap/mail/thread/methods.go
@@ -152,9 +152,10 @@ func (h *handlerSet) listAllMessages(ctx context.Context, p store.Principal) ([]
 // back into Thread/get always resolves to a thread row.
 //
 // Thread assignment happens at ingest time: InsertMessage resolves
-// references via ParseReferences(env_in_reply_to) and looks up ancestor
-// messages by env_message_id in the same principal's mailboxes. The
-// resolved thread_id is persisted so this read path is a simple group-by.
+// references by checking both env_in_reply_to and env_references (per
+// RFC 5256 sec 2.2 and RFC 8621 sec 8.1) and looks up ancestor messages
+// by env_message_id in the same principal's mailboxes. The resolved
+// thread_id is persisted so this read path is a simple group-by.
 func (h *handlerSet) computeForPrincipal(ctx context.Context, p store.Principal) (map[store.MessageID]ThreadKey, map[ThreadKey][]store.Message, error) {
 	msgs, err := h.listAllMessages(ctx, p)
 	if err != nil {

--- a/internal/protojmap/mail/thread/thread_test.go
+++ b/internal/protojmap/mail/thread/thread_test.go
@@ -50,18 +50,24 @@ func setup(t *testing.T) (*handlerSet, store.Store, store.Principal, store.Mailb
 
 func insertMsg(t *testing.T, st store.Store, mb store.Mailbox, msgID, inReplyTo, subject string) store.MessageID {
 	t.Helper()
+	return insertMsgWithRefs(t, st, mb, msgID, inReplyTo, "", subject)
+}
+
+func insertMsgWithRefs(t *testing.T, st store.Store, mb store.Mailbox, msgID, inReplyTo, references, subject string) store.MessageID {
+	t.Helper()
 	uid, _, err := st.Meta().InsertMessage(context.Background(), store.Message{
 		Blob: store.BlobRef{Hash: "deadbeef" + msgID, Size: 1},
 		Envelope: store.Envelope{
-			Subject:   subject,
-			MessageID: msgID,
-			InReplyTo: inReplyTo,
+			Subject:    subject,
+			MessageID:  msgID,
+			InReplyTo:  inReplyTo,
+			References: references,
 		},
 	}, []store.MessageMailbox{{MailboxID: mb.ID}})
 	if err != nil {
 		t.Fatalf("insert message: %v", err)
 	}
-	// Find the row's MessageID by UID — the store assigns IDs
+	// Find the row's MessageID by UID -- the store assigns IDs
 	// monotonically and exposes them through ListMessages.
 	msgs, err := st.Meta().ListMessages(context.Background(), mb.ID, store.MessageFilter{
 		Limit: 1000, WithEnvelope: true,
@@ -101,6 +107,48 @@ func TestThread_Get_DerivedFromMessages(t *testing.T) {
 		want := renderEmailID(mid)
 		if !strings.Contains(got, want) {
 			t.Fatalf("missing %s in %s", want, got)
+		}
+	}
+}
+
+// TestThread_Get_ReferencesHeader verifies that thread assignment uses the
+// References header, not only In-Reply-To. This is the root-cause scenario
+// for the six RFC 8621 conformance failures: msg3 replies to msg1 only via
+// References (no In-Reply-To), and must still land in the same thread.
+//
+// RFC 5256 sec 2.2 and RFC 8621 sec 8.1 both mandate unioning
+// In-Reply-To and References for thread resolution.
+func TestThread_Get_ReferencesHeader(t *testing.T) {
+	h, st, p, mb := setup(t)
+	// msg1: the thread root (no references).
+	id1 := insertMsg(t, st, mb, "<m1@example.test>", "", "Original subject")
+	// msg2: replies to msg1 via In-Reply-To (conventional reply).
+	id2 := insertMsg(t, st, mb, "<m2@example.test>", "<m1@example.test>", "Re: Original subject")
+	// msg3: references both ancestors via References only; In-Reply-To is empty.
+	// This is the failing scenario: without References-based resolution,
+	// msg3 would become its own singleton thread instead of joining the existing thread.
+	id3 := insertMsgWithRefs(t, st, mb,
+		"<m3@example.test>", "",
+		"<m1@example.test> <m2@example.test>",
+		"Re: Original subject")
+	args, _ := json.Marshal(map[string]any{"accountId": protojmap.AccountIDForPrincipal(p.ID)})
+	resp, mErr := getHandler{h: h}.executeAs(p, args)
+	if mErr != nil {
+		t.Fatalf("Thread/get: %v", mErr)
+	}
+	g := resp.(getResponse)
+	if len(g.List) != 1 {
+		t.Fatalf("expected 1 thread (got %d threads): msg3 should have been linked via References", len(g.List))
+	}
+	thr := g.List[0]
+	if len(thr.EmailIDs) != 3 {
+		t.Fatalf("expected 3 emails in thread, got %d: %+v", len(thr.EmailIDs), thr.EmailIDs)
+	}
+	got := strings.Join(thr.EmailIDs, ",")
+	for _, mid := range []store.MessageID{id1, id2, id3} {
+		want := renderEmailID(mid)
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %s in thread email list %s", want, got)
 		}
 	}
 }

--- a/internal/protosmtp/deliver.go
+++ b/internal/protosmtp/deliver.go
@@ -749,14 +749,25 @@ func envelopeFromParsed(msg mailparse.Message) store.Envelope {
 		}
 		return strings.Join(parts, ", ")
 	}
+	// Build the References value: re-bracket the already-normalized IDs
+	// so mailparse.ParseReferences can recover them in InsertMessage.
+	var refs string
+	if len(msg.Envelope.References) > 0 {
+		parts := make([]string, len(msg.Envelope.References))
+		for i, r := range msg.Envelope.References {
+			parts[i] = "<" + r + ">"
+		}
+		refs = strings.Join(parts, " ")
+	}
 	return store.Envelope{
-		Subject:   msg.Envelope.Subject,
-		From:      join(msg.Envelope.From),
-		To:        join(msg.Envelope.To),
-		Cc:        join(msg.Envelope.Cc),
-		Bcc:       join(msg.Envelope.Bcc),
-		MessageID: msg.Envelope.MessageID,
-		InReplyTo: strings.Join(msg.Envelope.InReplyTo, " "),
+		Subject:    msg.Envelope.Subject,
+		From:       join(msg.Envelope.From),
+		To:         join(msg.Envelope.To),
+		Cc:         join(msg.Envelope.Cc),
+		Bcc:        join(msg.Envelope.Bcc),
+		MessageID:  msg.Envelope.MessageID,
+		InReplyTo:  strings.Join(msg.Envelope.InReplyTo, " "),
+		References: refs,
 	}
 }
 

--- a/internal/store/storetest/storetest.go
+++ b/internal/store/storetest/storetest.go
@@ -39,6 +39,7 @@ func Run(t *testing.T, f Factory) {
 		{"MailboxConflict", testMailboxConflict},
 		{"MailboxConflict_ErrorStringIsClean", testMailboxConflictErrorStringIsClean},
 		{"InsertMessageAllocatesUIDAndModSeq", testInsertMessageAllocatesUIDAndModSeq},
+		{"InsertMessage_ThreadResolutionViaReferences", testInsertMessageThreadResolutionViaReferences},
 		{"UpdateFlagsBumpsModSeq", testUpdateFlagsBumpsModSeq},
 		{"UpdateFlagsUnchangedSince", testUpdateFlagsUnchangedSince},
 		{"UpdateFlagsKeywords", testUpdateFlagsKeywords},
@@ -692,6 +693,68 @@ func testInsertMessageAllocatesUIDAndModSeq(t *testing.T, s store.Store) {
 	}
 	if got.HighestModSeq != modseq2 {
 		t.Fatalf("HighestModSeq = %d, want %d", got.HighestModSeq, modseq2)
+	}
+}
+
+// testInsertMessageThreadResolutionViaReferences verifies that InsertMessage
+// assigns the same thread_id to three messages when the third message references
+// its ancestors only via the References header (no In-Reply-To). This is the
+// store-layer coverage for the RFC 8621 sec 8.1 / RFC 5256 sec 2.2 threading
+// requirement that was broken before migration 0041.
+func testInsertMessageThreadResolutionViaReferences(t *testing.T, s store.Store) {
+	ctx := ctxT(t)
+	p := mustInsertPrincipal(t, s, "threading@example.com")
+	mb := mustInsertMailbox(t, s, p.ID, "INBOX")
+	ref := putBlob(t, s, "msg-body-dummy")
+
+	insert := func(msgID, inReplyTo, references string) store.Message {
+		t.Helper()
+		_, _, err := s.Meta().InsertMessage(ctx, store.Message{
+			PrincipalID: p.ID,
+			Blob:        ref,
+			Size:        ref.Size,
+			Envelope: store.Envelope{
+				MessageID:  msgID,
+				InReplyTo:  inReplyTo,
+				References: references,
+			},
+		}, []store.MessageMailbox{{MailboxID: mb.ID}})
+		if err != nil {
+			t.Fatalf("InsertMessage %s: %v", msgID, err)
+		}
+		msgs, err := s.Meta().ListMessages(ctx, mb.ID, store.MessageFilter{Limit: 1000, WithEnvelope: true})
+		if err != nil {
+			t.Fatalf("ListMessages: %v", err)
+		}
+		for _, m := range msgs {
+			if m.Envelope.MessageID == msgID {
+				return m
+			}
+		}
+		t.Fatalf("message %s not found after insert", msgID)
+		return store.Message{}
+	}
+
+	// msg1: thread root.
+	msg1 := insert("msg1@test", "", "")
+	// msg2: conventional reply via In-Reply-To.
+	msg2 := insert("msg2@test", "<msg1@test>", "<msg1@test>")
+	// msg3: references both ancestors via References only; In-Reply-To is absent.
+	// This is the failing scenario for the conformance suite.
+	msg3 := insert("msg3@test", "", "<msg1@test> <msg2@test>")
+
+	// All three must share the same effective thread key.
+	// The store uses thread_id == 0 to mean "key is the message id itself".
+	threadKey := func(m store.Message) uint64 {
+		if m.ThreadID != 0 {
+			return m.ThreadID
+		}
+		return uint64(m.ID)
+	}
+	k1, k2, k3 := threadKey(msg1), threadKey(msg2), threadKey(msg3)
+	if k1 != k2 || k2 != k3 {
+		t.Fatalf("thread keys diverge: msg1=%d msg2=%d msg3=%d; msg3 should be linked via References",
+			k1, k2, k3)
 	}
 }
 

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -283,6 +283,15 @@ type Envelope struct {
 	MessageID string
 	// InReplyTo is the decoded In-Reply-To header.
 	InReplyTo string
+	// References holds the raw References header value. This is used
+	// exclusively for thread resolution at ingest time: InsertMessage
+	// checks both InReplyTo and References to find an ancestor message
+	// in the same thread, so that messages related by References but not
+	// by a direct In-Reply-To pair still land in the same thread per
+	// RFC 8621 sec 8.1. Not surfaced on the IMAP ENVELOPE response (which
+	// has no References slot); the JMAP render path reads References from
+	// the blob directly.
+	References string
 	// Date is the parsed Date header; zero value if absent or unparsable.
 	Date time.Time
 }

--- a/internal/storepg/metadata.go
+++ b/internal/storepg/metadata.go
@@ -758,8 +758,26 @@ func (m *metadata) InsertMessage(ctx context.Context, msg store.Message, targets
 			msg.Envelope.MessageID = mailparse.NormalizeMessageID(msg.Envelope.MessageID)
 		}
 		// Thread resolution using principal_id directly (post-migration 0024).
-		if msg.ThreadID == 0 && msg.Envelope.InReplyTo != "" {
+		// RFC 5256 sec 2.2 and RFC 8621 sec 8.1: check both In-Reply-To
+		// and References headers. References lists the full ancestry chain
+		// and is the authoritative source; In-Reply-To is a single-hop
+		// shortcut that may be the only reference present in some clients.
+		// We union them (In-Reply-To first for historical compat) and take
+		// the first match found.
+		if msg.ThreadID == 0 {
 			refs := mailparse.ParseReferences(msg.Envelope.InReplyTo)
+			// Append unique References entries after InReplyTo entries so
+			// that a direct In-Reply-To match wins when both are present.
+			seen := make(map[string]struct{}, len(refs))
+			for _, r := range refs {
+				seen[r] = struct{}{}
+			}
+			for _, r := range mailparse.ParseReferences(msg.Envelope.References) {
+				if _, dup := seen[r]; !dup {
+					refs = append(refs, r)
+					seen[r] = struct{}{}
+				}
+			}
 			for _, ref := range refs {
 				var ancestorID, ancestorThread int64
 				lookupErr := tx.QueryRow(ctx, `
@@ -789,15 +807,15 @@ func (m *metadata) InsertMessage(ctx context.Context, msg store.Message, targets
 			INSERT INTO messages (principal_id,
 			  internal_date_us, received_at_us, size, blob_hash, blob_size, thread_id,
 			  env_subject, env_from, env_to, env_cc, env_bcc, env_reply_to,
-			  env_message_id, env_in_reply_to, env_date_us)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
+			  env_message_id, env_in_reply_to, env_references, env_date_us)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
 			RETURNING id`,
 			pid,
 			usMicros(msg.InternalDate), usMicros(msg.ReceivedAt), msg.Size,
 			msg.Blob.Hash, msg.Blob.Size, int64(msg.ThreadID),
 			msg.Envelope.Subject, msg.Envelope.From, msg.Envelope.To,
 			msg.Envelope.Cc, msg.Envelope.Bcc, msg.Envelope.ReplyTo,
-			msg.Envelope.MessageID, msg.Envelope.InReplyTo, usMicros(msg.Envelope.Date),
+			msg.Envelope.MessageID, msg.Envelope.InReplyTo, msg.Envelope.References, usMicros(msg.Envelope.Date),
 		).Scan(&mid); err != nil {
 			return mapErr(err)
 		}
@@ -891,11 +909,11 @@ func (m *metadata) ReplaceMessageBody(
 			UPDATE messages
 			   SET blob_hash = $1, blob_size = $2, size = $3,
 			       env_subject = $4, env_from = $5, env_to = $6, env_cc = $7, env_bcc = $8, env_reply_to = $9,
-			       env_message_id = $10, env_in_reply_to = $11, env_date_us = $12
-			 WHERE id = $13`,
+			       env_message_id = $10, env_in_reply_to = $11, env_references = $12, env_date_us = $13
+			 WHERE id = $14`,
 			ref.Hash, ref.Size, size,
 			env.Subject, env.From, env.To, env.Cc, env.Bcc, env.ReplyTo,
-			env.MessageID, env.InReplyTo, usMicros(env.Date),
+			env.MessageID, env.InReplyTo, env.References, usMicros(env.Date),
 			int64(id),
 		); err != nil {
 			return mapErr(err)
@@ -960,7 +978,7 @@ func (m *metadata) GetMessage(ctx context.Context, id store.MessageID) (store.Me
 		SELECT id, principal_id, internal_date_us, received_at_us, size,
 		       blob_hash, blob_size, thread_id,
 		       env_subject, env_from, env_to, env_cc, env_bcc, env_reply_to,
-		       env_message_id, env_in_reply_to, env_date_us
+		       env_message_id, env_in_reply_to, env_references, env_date_us
 		  FROM messages WHERE id = $1`, int64(id))
 	msg, err := scanMessageRow(row)
 	if err != nil {
@@ -984,7 +1002,7 @@ func scanMessageRow(row rowLike) (store.Message, error) {
 		&msg.Size, &msg.Blob.Hash, &blobSize, &thread,
 		&msg.Envelope.Subject, &msg.Envelope.From, &msg.Envelope.To,
 		&msg.Envelope.Cc, &msg.Envelope.Bcc, &msg.Envelope.ReplyTo,
-		&msg.Envelope.MessageID, &msg.Envelope.InReplyTo, &envDateUs)
+		&msg.Envelope.MessageID, &msg.Envelope.InReplyTo, &msg.Envelope.References, &envDateUs)
 	if err != nil {
 		return store.Message{}, mapErr(err)
 	}
@@ -1070,7 +1088,7 @@ func scanMessage(row rowLike) (store.Message, error) {
 		&msg.Size, &msg.Blob.Hash, &blobSize, &thread,
 		&msg.Envelope.Subject, &msg.Envelope.From, &msg.Envelope.To,
 		&msg.Envelope.Cc, &msg.Envelope.Bcc, &msg.Envelope.ReplyTo,
-		&msg.Envelope.MessageID, &msg.Envelope.InReplyTo, &envDateUs,
+		&msg.Envelope.MessageID, &msg.Envelope.InReplyTo, &msg.Envelope.References, &envDateUs,
 		// message_mailboxes columns
 		&mbox, &uid, &modseq, &flags, &keywords, &snoozedUs,
 	)
@@ -2286,7 +2304,7 @@ func (m *metadata) ListMessages(ctx context.Context, mailboxID store.MailboxID, 
 			SELECT m.id, m.principal_id, m.internal_date_us, m.received_at_us,
 			       m.size, m.blob_hash, m.blob_size, m.thread_id,
 			       m.env_subject, m.env_from, m.env_to, m.env_cc, m.env_bcc, m.env_reply_to,
-			       m.env_message_id, m.env_in_reply_to, m.env_date_us,
+			       m.env_message_id, m.env_in_reply_to, m.env_references, m.env_date_us,
 			       mm.mailbox_id, mm.uid, mm.modseq, mm.flags, mm.keywords_csv, mm.snoozed_until_us
 			  FROM messages m
 			  JOIN message_mailboxes mm ON mm.message_id = m.id AND mm.mailbox_id = $1
@@ -2298,7 +2316,7 @@ func (m *metadata) ListMessages(ctx context.Context, mailboxID store.MailboxID, 
 			SELECT m.id, m.principal_id, m.internal_date_us, m.received_at_us,
 			       m.size, m.blob_hash, m.blob_size, m.thread_id,
 			       m.env_subject, m.env_from, m.env_to, m.env_cc, m.env_bcc, m.env_reply_to,
-			       m.env_message_id, m.env_in_reply_to, m.env_date_us,
+			       m.env_message_id, m.env_in_reply_to, m.env_references, m.env_date_us,
 			       mm.mailbox_id, mm.uid, mm.modseq, mm.flags, mm.keywords_csv, mm.snoozed_until_us
 			  FROM messages m
 			  JOIN message_mailboxes mm ON mm.message_id = m.id AND mm.mailbox_id = $1
@@ -2545,7 +2563,7 @@ func (m *metadata) ListDueSnoozedMessages(ctx context.Context, now time.Time, li
 		SELECT m.id, m.principal_id, m.internal_date_us, m.received_at_us,
 		       m.size, m.blob_hash, m.blob_size, m.thread_id,
 		       m.env_subject, m.env_from, m.env_to, m.env_cc, m.env_bcc, m.env_reply_to,
-		       m.env_message_id, m.env_in_reply_to, m.env_date_us,
+		       m.env_message_id, m.env_in_reply_to, m.env_references, m.env_date_us,
 		       mm.mailbox_id, mm.uid, mm.modseq, mm.flags, mm.keywords_csv, mm.snoozed_until_us
 		  FROM messages m
 		  JOIN message_mailboxes mm ON mm.message_id = m.id

--- a/internal/storepg/migrations/0041_messages_env_references.sql
+++ b/internal/storepg/migrations/0041_messages_env_references.sql
@@ -1,0 +1,18 @@
+-- 0041_messages_env_references.sql — add env_references column to messages.
+--
+-- Thread resolution in InsertMessage previously only consulted the
+-- In-Reply-To header to find ancestor messages. The References header
+-- lists the full ancestry chain and is the authoritative source per
+-- RFC 5256 sec 2.2 and RFC 8621 sec 8.1. Without it, messages that
+-- reference an ancestor only via References (not In-Reply-To) end up in
+-- separate threads, breaking Thread/get, someInThreadHaveKeyword,
+-- noneInThreadHaveKeyword, and collapseThreads.
+--
+-- The new column stores the raw References header value for thread-
+-- resolution use at ingest time. Existing rows default to '' (empty
+-- string) which is equivalent to "no References header" and preserves
+-- the existing threading for already-stored messages.
+--
+-- Forward-only. Mirrors storesqlite 0041.
+
+ALTER TABLE messages ADD COLUMN env_references TEXT NOT NULL DEFAULT '';

--- a/internal/storesqlite/metadata.go
+++ b/internal/storesqlite/metadata.go
@@ -842,7 +842,7 @@ func scanMessageRow(row rowLike) (store.Message, error) {
 		&msg.Size, &thread,
 		&msg.Envelope.Subject, &msg.Envelope.From, &msg.Envelope.To,
 		&msg.Envelope.Cc, &msg.Envelope.Bcc, &msg.Envelope.ReplyTo,
-		&msg.Envelope.MessageID, &msg.Envelope.InReplyTo, &envDateUs)
+		&msg.Envelope.MessageID, &msg.Envelope.InReplyTo, &msg.Envelope.References, &envDateUs)
 	if err != nil {
 		return store.Message{}, mapErr(err)
 	}
@@ -951,8 +951,26 @@ func (m *metadata) InsertMessage(ctx context.Context, msg store.Message, targets
 			msg.Envelope.MessageID = mailparse.NormalizeMessageID(msg.Envelope.MessageID)
 		}
 		// Thread resolution against the principal's existing messages.
-		if msg.ThreadID == 0 && msg.Envelope.InReplyTo != "" {
+		// RFC 5256 sec 2.2 and RFC 8621 sec 8.1: check both In-Reply-To
+		// and References headers. References lists the full ancestry chain
+		// and is the authoritative source; In-Reply-To is a single-hop
+		// shortcut that may be the only reference present in some clients.
+		// We union them (In-Reply-To first for historical compat) and take
+		// the first match found.
+		if msg.ThreadID == 0 {
 			refs := mailparse.ParseReferences(msg.Envelope.InReplyTo)
+			// Append unique References entries after InReplyTo entries so
+			// that a direct In-Reply-To match wins when both are present.
+			seen := make(map[string]struct{}, len(refs))
+			for _, r := range refs {
+				seen[r] = struct{}{}
+			}
+			for _, r := range mailparse.ParseReferences(msg.Envelope.References) {
+				if _, dup := seen[r]; !dup {
+					refs = append(refs, r)
+					seen[r] = struct{}{}
+				}
+			}
 			for _, ref := range refs {
 				var ancestorID, ancestorThread int64
 				lookupErr := tx.QueryRowContext(ctx, `
@@ -981,13 +999,13 @@ func (m *metadata) InsertMessage(ctx context.Context, msg store.Message, targets
 			INSERT INTO messages (principal_id, blob_hash, blob_size,
 			  internal_date_us, received_at_us, size, thread_id,
 			  env_subject, env_from, env_to, env_cc, env_bcc, env_reply_to,
-			  env_message_id, env_in_reply_to, env_date_us)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			  env_message_id, env_in_reply_to, env_references, env_date_us)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			pid, msg.Blob.Hash, msg.Blob.Size,
 			usMicros(msg.InternalDate), usMicros(msg.ReceivedAt), msg.Size, int64(msg.ThreadID),
 			msg.Envelope.Subject, msg.Envelope.From, msg.Envelope.To,
 			msg.Envelope.Cc, msg.Envelope.Bcc, msg.Envelope.ReplyTo,
-			msg.Envelope.MessageID, msg.Envelope.InReplyTo, usMicros(msg.Envelope.Date))
+			msg.Envelope.MessageID, msg.Envelope.InReplyTo, msg.Envelope.References, usMicros(msg.Envelope.Date))
 		if err != nil {
 			return mapErr(err)
 		}
@@ -1088,11 +1106,11 @@ func (m *metadata) ReplaceMessageBody(
 			UPDATE messages
 			   SET blob_hash = ?, blob_size = ?, size = ?,
 			       env_subject = ?, env_from = ?, env_to = ?, env_cc = ?, env_bcc = ?, env_reply_to = ?,
-			       env_message_id = ?, env_in_reply_to = ?, env_date_us = ?
+			       env_message_id = ?, env_in_reply_to = ?, env_references = ?, env_date_us = ?
 			 WHERE id = ?`,
 			ref.Hash, ref.Size, size,
 			env.Subject, env.From, env.To, env.Cc, env.Bcc, env.ReplyTo,
-			env.MessageID, env.InReplyTo, usMicros(env.Date),
+			env.MessageID, env.InReplyTo, env.References, usMicros(env.Date),
 			int64(id),
 		); err != nil {
 			return mapErr(err)
@@ -1164,7 +1182,7 @@ func (m *metadata) GetMessage(ctx context.Context, id store.MessageID) (store.Me
 		SELECT id, principal_id, blob_hash, blob_size, internal_date_us,
 		       received_at_us, size, thread_id,
 		       env_subject, env_from, env_to, env_cc, env_bcc, env_reply_to,
-		       env_message_id, env_in_reply_to, env_date_us
+		       env_message_id, env_in_reply_to, env_references, env_date_us
 		  FROM messages WHERE id = ?`, int64(id))
 	msg, err := scanMessageRow(row)
 	if err != nil {
@@ -1195,7 +1213,7 @@ func scanMessage(row rowLike) (store.Message, error) {
 		&msg.Size, &thread,
 		&msg.Envelope.Subject, &msg.Envelope.From, &msg.Envelope.To,
 		&msg.Envelope.Cc, &msg.Envelope.Bcc, &msg.Envelope.ReplyTo,
-		&msg.Envelope.MessageID, &msg.Envelope.InReplyTo, &envDateUs,
+		&msg.Envelope.MessageID, &msg.Envelope.InReplyTo, &msg.Envelope.References, &envDateUs,
 		// message_mailboxes
 		&mbox, &uid, &modseq, &flags, &keywords, &snoozedUs,
 	)
@@ -2486,7 +2504,7 @@ func (m *metadata) ListMessages(ctx context.Context, mailboxID store.MailboxID, 
 			SELECT m.id, m.principal_id, m.blob_hash, m.blob_size, m.internal_date_us,
 			       m.received_at_us, m.size, m.thread_id,
 			       m.env_subject, m.env_from, m.env_to, m.env_cc, m.env_bcc, m.env_reply_to,
-			       m.env_message_id, m.env_in_reply_to, m.env_date_us,
+			       m.env_message_id, m.env_in_reply_to, m.env_references, m.env_date_us,
 			       mm.mailbox_id, mm.uid, mm.modseq, mm.flags, mm.keywords_csv, mm.snoozed_until_us
 			  FROM messages m
 			  JOIN message_mailboxes mm ON mm.message_id = m.id
@@ -2498,7 +2516,7 @@ func (m *metadata) ListMessages(ctx context.Context, mailboxID store.MailboxID, 
 			SELECT m.id, m.principal_id, m.blob_hash, m.blob_size, m.internal_date_us,
 			       m.received_at_us, m.size, m.thread_id,
 			       m.env_subject, m.env_from, m.env_to, m.env_cc, m.env_bcc, m.env_reply_to,
-			       m.env_message_id, m.env_in_reply_to, m.env_date_us,
+			       m.env_message_id, m.env_in_reply_to, m.env_references, m.env_date_us,
 			       mm.mailbox_id, mm.uid, mm.modseq, mm.flags, mm.keywords_csv, mm.snoozed_until_us
 			  FROM messages m
 			  JOIN message_mailboxes mm ON mm.message_id = m.id
@@ -2772,7 +2790,7 @@ func (m *metadata) ListDueSnoozedMessages(ctx context.Context, now time.Time, li
 		SELECT m.id, m.principal_id, m.blob_hash, m.blob_size, m.internal_date_us,
 		       m.received_at_us, m.size, m.thread_id,
 		       m.env_subject, m.env_from, m.env_to, m.env_cc, m.env_bcc, m.env_reply_to,
-		       m.env_message_id, m.env_in_reply_to, m.env_date_us,
+		       m.env_message_id, m.env_in_reply_to, m.env_references, m.env_date_us,
 		       mm.mailbox_id, mm.uid, mm.modseq, mm.flags, mm.keywords_csv, mm.snoozed_until_us
 		  FROM messages m
 		  JOIN message_mailboxes mm ON mm.message_id = m.id

--- a/internal/storesqlite/migrations/0041_messages_env_references.sql
+++ b/internal/storesqlite/migrations/0041_messages_env_references.sql
@@ -1,0 +1,18 @@
+-- 0041_messages_env_references.sql — add env_references column to messages.
+--
+-- Thread resolution in InsertMessage previously only consulted the
+-- In-Reply-To header to find ancestor messages. The References header
+-- lists the full ancestry chain and is the authoritative source per
+-- RFC 5256 sec 2.2 and RFC 8621 sec 8.1. Without it, messages that
+-- reference an ancestor only via References (not In-Reply-To) end up in
+-- separate threads, breaking Thread/get, someInThreadHaveKeyword,
+-- noneInThreadHaveKeyword, and collapseThreads.
+--
+-- The new column stores the raw References header value for thread-
+-- resolution use at ingest time. Existing rows default to '' (empty
+-- string) which is equivalent to "no References header" and preserves
+-- the existing threading for already-stored messages.
+--
+-- Forward-only. Mirrors storepg 0041.
+
+ALTER TABLE messages ADD COLUMN env_references TEXT NOT NULL DEFAULT '';


### PR DESCRIPTION
## Summary

- Thread resolution in `InsertMessage` only checked `In-Reply-To` header, ignoring `References`. This caused 6 jmapio/jmap-test-suite conformance failures (RFC 8621 sec 8.1 / RFC 5256 sec 2.2 mandate unioning both).
- Added `References string` to `store.Envelope`, persisted via migration 0041 (`env_references TEXT NOT NULL DEFAULT ''`), and updated `InsertMessage` in both SQLite and Postgres to probe a deduped union of `ParseReferences(InReplyTo) + ParseReferences(References)` for an ancestor message.
- All callers that build `store.Envelope` from parsed messages (`buildEnvelopeFromParsed`, `envelopeFromParsed`, `parseEnvelope`) updated to populate `References`.
- `relinkThreads` (post-import pass) updated to also check `References`.
- Backup adapter and rows updated for the new column.

## Affected REQ IDs

- REQ-PROTO-41 (JMAP Mail -- Thread/get, Email/query)
- REQ-PROTO-47 (Email/query backed by shared FTS + store)

## Previously failing tests (now passing)

From CI run 25340009509 artifact `jmap-report.json`:

```
thread/get-thread-by-id       Thread/get returns thread with emailIds
email/get-thread-id-consistent  Email/get threadId is consistent for threaded emails
email/filter-some-in-thread-have-keyword  Email/query filter someInThreadHaveKeyword matches
email/filter-none-in-thread-have-keyword  Email/query filter noneInThreadHaveKeyword excludes
email/collapse-threads-with-filter        Email/query collapseThreads interacts correctly with filter
email/collapse-threads-sort-determines-representative  Email/query collapseThreads uses sort to pick representative
```

## Test plan

- `go test -tags nofrontend ./internal/protojmap/mail/thread/...` -- PASS (new `TestThread_Get_ReferencesHeader`)
- `go test -tags nofrontend ./internal/storesqlite/...` -- PASS (170 tests incl. new `InsertMessage_ThreadResolutionViaReferences`)
- `go test -tags nofrontend ./internal/...` (all packages) -- PASS (excluding pre-existing admin SPA stub failure)
- `make fmt-check vet check-schema-version` -- PASS
- `test/interop/run-jmaptest.sh` locally: **309 total, 304 passed, 0 failed, 5 skipped** (was 298 passed, 6 failed)

The 5 skipped tests are pre-existing skips unrelated to threading.