### PR TITLE
store, mail workers: persist cursor on shutdown across 5 workers

### DIFF
--- a/internal/maildmarc/intake.go
+++ b/internal/maildmarc/intake.go
@@ -127,6 +127,11 @@ func (i *Intake) Run(ctx context.Context) error {
 		return errors.New("maildmarc: Intake already running")
 	}
 	defer i.running.Store(false)
+	// Final flush on shutdown so the in-memory cursor reflects on
+	// disk even when the in-loop SetFTSCursor lost its race with
+	// ctx cancellation. Uses a fresh, short-deadline ctx so the
+	// flush itself is not cancelled the moment it starts.
+	defer i.persistCursorOnShutdown()
 
 	if seq, err := i.meta.GetFTSCursor(ctx, i.opts.CursorKey); err != nil {
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
@@ -185,6 +190,28 @@ func (i *Intake) Run(ctx context.Context) error {
 				)
 			}
 		}
+	}
+}
+
+// persistCursorOnShutdown writes the in-memory cursor to the durable
+// store using a fresh ctx, so the worker's last advance lands even when
+// the run ctx is already cancelled. Called from Run's defer chain.
+func (i *Intake) persistCursorOnShutdown() {
+	seq := i.cursor.Load()
+	if seq == 0 {
+		return
+	}
+	flushCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := i.meta.SetFTSCursor(flushCtx, i.opts.CursorKey, seq); err != nil {
+		i.logger.WarnContext(flushCtx, "maildmarc: persist intake cursor on shutdown",
+			slog.String("activity", "internal"),
+			slog.String("subsystem", "maildmarc"),
+			slog.String("worker", "ingest"),
+			slog.String("key", i.opts.CursorKey),
+			slog.Uint64("seq", seq),
+			slog.Any("err", err),
+		)
 	}
 }
 

--- a/internal/maildmarc/intake_test.go
+++ b/internal/maildmarc/intake_test.go
@@ -218,12 +218,23 @@ func TestIntake_PersistsCursorOnShutdown(t *testing.T) {
 	cancel()
 	<-done
 
+	// The intake may tick once more between the memCursor sample and
+	// the cancel, so the value flushed by the shutdown defer can be
+	// >= memCursor. Read the final in-memory cursor after Run has
+	// returned and assert against that.
+	finalMem := intake.Cursor()
+
 	persisted, err := fs.Meta().GetFTSCursor(context.Background(), cursorKey)
 	if err != nil {
 		t.Fatalf("GetFTSCursor post-shutdown: %v", err)
 	}
-	if persisted != memCursor {
-		t.Fatalf("post-shutdown persisted cursor = %d, in-memory cursor = %d (shutdown flush did not run)", persisted, memCursor)
+	if persisted != finalMem {
+		t.Fatalf("post-shutdown persisted cursor = %d, final in-memory cursor = %d (memCursor sample was %d) (shutdown flush did not run)",
+			persisted, finalMem, memCursor)
+	}
+	if persisted < memCursor {
+		t.Fatalf("post-shutdown persisted cursor = %d trailed observed in-memory cursor %d",
+			persisted, memCursor)
 	}
 
 	// Restart with the same cursor key on the unwrapped store. The

--- a/internal/maildmarc/intake_test.go
+++ b/internal/maildmarc/intake_test.go
@@ -122,6 +122,136 @@ func TestIntake_PollsChangeFeed_FiltersByRecipientPattern(t *testing.T) {
 	}
 }
 
+// shutdownFlushStore wraps a real store so the in-loop SetFTSCursor
+// path returns context.Canceled while the shutdown-path SetFTSCursor
+// (which uses a fresh background context) is allowed through. With
+// the fix, the worker writes the advanced cursor on its way out via a
+// fresh ctx; without the fix, every SetFTSCursor would carry the
+// cancelled run ctx and the persisted cursor would lag the in-memory
+// advance, causing a restart to re-process the report.
+type shutdownFlushStore struct {
+	store.Store
+	failingMeta *shutdownFlushMeta
+}
+
+func (s shutdownFlushStore) Meta() store.Metadata { return s.failingMeta }
+
+type shutdownFlushMeta struct {
+	store.Metadata
+	parentCtx context.Context
+}
+
+func (m *shutdownFlushMeta) SetFTSCursor(ctx context.Context, key string, seq uint64) error {
+	if ctx == m.parentCtx {
+		return context.Canceled
+	}
+	return m.Metadata.SetFTSCursor(ctx, key, seq)
+}
+
+// TestIntake_PersistsCursorOnShutdown asserts that the worker's
+// shutdown defer flushes the in-memory cursor when the in-loop
+// SetFTSCursor lost its race with ctx cancellation. Restart with the
+// same cursor key must NOT re-ingest the seeded report.
+func TestIntake_PersistsCursorOnShutdown(t *testing.T) {
+	clk := clock.NewFake(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	fs, err := storesqlite.Open(context.Background(), filepath.Join(t.TempDir(), "store.db"), nil, clk)
+	if err != nil {
+		t.Fatalf("storesqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = fs.Close() })
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	att := gzReportBytes(t, sampleReportXML)
+	raw := buildReportEmail(
+		"google.com!example.test!1700000000!1700086400.xml.gz",
+		"application/gzip",
+		att,
+	)
+	_ = seedDMARCReportMessage(t, fs, "dmarc-reports@example.test", raw)
+
+	const cursorKey = "dmarc-intake-shutdown-test"
+	runCtx, cancel := context.WithCancel(context.Background())
+	wrapped := shutdownFlushStore{
+		Store:       fs,
+		failingMeta: &shutdownFlushMeta{Metadata: fs.Meta(), parentCtx: runCtx},
+	}
+
+	ing := maildmarc.NewIngestor(fs.Meta(), logger, clk)
+	intake := maildmarc.NewIntake(wrapped, ing, logger, clk, maildmarc.IntakeOptions{
+		PollInterval:     20 * time.Millisecond,
+		RecipientPattern: "dmarc-reports@",
+		CursorKey:        cursorKey,
+	})
+
+	done := make(chan error, 1)
+	go func() { done <- intake.Run(runCtx) }()
+
+	// Drive the worker until it has ingested the report (the in-loop
+	// cursor write fails, but the in-memory cursor advances and the
+	// report row lands).
+	deadline := time.Now().Add(3 * time.Second)
+	var ingested bool
+	for time.Now().Before(deadline) {
+		clk.Advance(20 * time.Millisecond)
+		reports, _ := fs.Meta().ListDMARCReports(context.Background(), store.DMARCReportFilter{})
+		if len(reports) == 1 {
+			ingested = true
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !ingested {
+		cancel()
+		<-done
+		t.Fatalf("first intake did not ingest the report")
+	}
+
+	memCursor := intake.Cursor()
+	if memCursor == 0 {
+		cancel()
+		<-done
+		t.Fatalf("first intake's in-memory cursor did not advance")
+	}
+
+	// Cancel and wait for Run to return; the shutdown defer must
+	// persist the cursor via a fresh ctx.
+	cancel()
+	<-done
+
+	persisted, err := fs.Meta().GetFTSCursor(context.Background(), cursorKey)
+	if err != nil {
+		t.Fatalf("GetFTSCursor post-shutdown: %v", err)
+	}
+	if persisted != memCursor {
+		t.Fatalf("post-shutdown persisted cursor = %d, in-memory cursor = %d (shutdown flush did not run)", persisted, memCursor)
+	}
+
+	// Restart with the same cursor key on the unwrapped store. The
+	// new worker must NOT re-ingest the report (no second
+	// ListDMARCReports row appears).
+	intake2 := maildmarc.NewIntake(fs, ing, logger, clk, maildmarc.IntakeOptions{
+		PollInterval:     20 * time.Millisecond,
+		RecipientPattern: "dmarc-reports@",
+		CursorKey:        cursorKey,
+	})
+	runCtx2, cancel2 := context.WithCancel(context.Background())
+	done2 := make(chan error, 1)
+	go func() { done2 <- intake2.Run(runCtx2) }()
+	// Give the second worker a few poll cycles so it would re-ingest
+	// if the cursor were not honoured.
+	for j := 0; j < 5; j++ {
+		clk.Advance(20 * time.Millisecond)
+		time.Sleep(20 * time.Millisecond)
+	}
+	cancel2()
+	<-done2
+
+	reports, _ := fs.Meta().ListDMARCReports(context.Background(), store.DMARCReportFilter{})
+	if len(reports) != 1 {
+		t.Fatalf("after restart reports = %d, want 1 (no double ingest)", len(reports))
+	}
+}
+
 func TestIntake_AdvancesCursor(t *testing.T) {
 	clk := clock.NewFake(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
 	fs, err := storesqlite.Open(context.Background(), filepath.Join(t.TempDir(), "store.db"), nil, clk)

--- a/internal/protoevents/dispatcher.go
+++ b/internal/protoevents/dispatcher.go
@@ -213,6 +213,11 @@ func (d *Dispatcher) runEmitLoop(ctx context.Context) {
 // to its mail-flow event, and feeds the result into Emit. Cursor
 // persistence uses the cursors table keyed "events.changefeed.<pid>"
 // so a restart resumes from the last emitted change.
+//
+// On every return path (ctx cancellation, fatal error) the in-memory
+// cursor is flushed to the durable store via a fresh, short-deadline
+// ctx so an advance that raced with cancellation still lands on disk
+// and a restart does not replay events that the loop already emitted.
 func (d *Dispatcher) runChangeFeedLoop(ctx context.Context, pid store.PrincipalID) {
 	cursorKey := fmt.Sprintf("events.changefeed.%d", pid)
 	meta := d.opts.Store.Meta()
@@ -223,6 +228,23 @@ func (d *Dispatcher) runChangeFeedLoop(ctx context.Context, pid store.PrincipalI
 			"err", err, "pid", pid)
 	}
 	cursor := store.ChangeSeq(cur)
+	// On exit, persist whatever the in-memory cursor advanced to. We
+	// capture it by reference so each return path observes the latest
+	// value. The fresh ctx covers the case where ctx is already
+	// cancelled; without it the SetFTSCursor would fail immediately
+	// with context.Canceled and the in-loop advance would be lost.
+	defer func() {
+		if uint64(cursor) == 0 || uint64(cursor) == cur {
+			return
+		}
+		flushCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := meta.SetFTSCursor(flushCtx, cursorKey, uint64(cursor)); err != nil {
+			d.opts.Logger.Warn("protoevents.changefeed.cursor_save_on_shutdown_failed",
+				"activity", observe.ActivityInternal,
+				"err", err, "pid", pid, "seq", uint64(cursor))
+		}
+	}()
 	for {
 		select {
 		case <-ctx.Done():

--- a/internal/protoevents/dispatcher_test.go
+++ b/internal/protoevents/dispatcher_test.go
@@ -482,6 +482,246 @@ firstDone:
 	t.Fatalf("second dispatcher did not deliver mail.received")
 }
 
+// shutdownFlushStore wraps a real store so the in-loop SetFTSCursor
+// path returns context.Canceled while the shutdown-path SetFTSCursor
+// (which uses a fresh background ctx) is allowed through. Models the
+// race the cursor-on-shutdown fix guards against.
+type shutdownFlushStore struct {
+	store.Store
+	failingMeta *shutdownFlushMeta
+}
+
+func (s shutdownFlushStore) Meta() store.Metadata { return s.failingMeta }
+
+type shutdownFlushMeta struct {
+	store.Metadata
+	parentCtx context.Context
+}
+
+func (m *shutdownFlushMeta) SetFTSCursor(ctx context.Context, key string, seq uint64) error {
+	if ctx == m.parentCtx {
+		return context.Canceled
+	}
+	return m.Metadata.SetFTSCursor(ctx, key, seq)
+}
+
+// TestPerPrincipalCursors_PersistOnShutdown drives two principals'
+// change feeds, models the race where the in-loop SetFTSCursor returns
+// context.Canceled, then cancels and verifies BOTH per-principal
+// cursors land on disk via each goroutine's shutdown defer. Restart
+// then must not replay either principal's events.
+func TestPerPrincipalCursors_PersistOnShutdown(t *testing.T) {
+	t.Parallel()
+	clk := clock.NewFake(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	st, err := storesqlite.OpenWithRand(context.Background(), dbPath, nil, clk, rand.Reader)
+	if err != nil {
+		t.Fatalf("storesqlite.OpenWithRand: %v", err)
+	}
+	defer st.Close()
+
+	seedCtx := context.Background()
+	pA, err := st.Meta().InsertPrincipal(seedCtx, store.Principal{
+		Kind: store.PrincipalKindUser, CanonicalEmail: "alice@example.com",
+	})
+	if err != nil {
+		t.Fatalf("InsertPrincipal A: %v", err)
+	}
+	pB, err := st.Meta().InsertPrincipal(seedCtx, store.Principal{
+		Kind: store.PrincipalKindUser, CanonicalEmail: "bob@example.com",
+	})
+	if err != nil {
+		t.Fatalf("InsertPrincipal B: %v", err)
+	}
+	mbA, err := st.Meta().InsertMailbox(seedCtx, store.Mailbox{PrincipalID: pA.ID, Name: "INBOX"})
+	if err != nil {
+		t.Fatalf("InsertMailbox A: %v", err)
+	}
+	mbB, err := st.Meta().InsertMailbox(seedCtx, store.Mailbox{PrincipalID: pB.ID, Name: "INBOX"})
+	if err != nil {
+		t.Fatalf("InsertMailbox B: %v", err)
+	}
+
+	deliveriesA := make(chan string, 16)
+	deliveriesB := make(chan string, 16)
+	inv := newFakeInvoker()
+	inv.Handle("bus", protoevents.MethodEventsPublish, func(_ context.Context, params any) error {
+		ev := params.(map[string]any)["event"].(map[string]any)
+		if ev["kind"] != string(protoevents.EventMailReceived) {
+			return nil
+		}
+		subject, _ := ev["subject"].(string)
+		payload, _ := ev["payload"].(map[string]any)
+		msgID, _ := payload["message_id"].(string)
+		switch subject {
+		case fmt.Sprintf("%d", pA.ID):
+			select {
+			case deliveriesA <- msgID:
+			default:
+			}
+		case fmt.Sprintf("%d", pB.ID):
+			select {
+			case deliveriesB <- msgID:
+			default:
+			}
+		}
+		return nil
+	})
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	wrapped := shutdownFlushStore{
+		Store:       st,
+		failingMeta: &shutdownFlushMeta{Metadata: st.Meta(), parentCtx: runCtx},
+	}
+	d, err := protoevents.New(protoevents.Options{
+		Store:                wrapped,
+		Plugins:              inv,
+		Logger:               discardLogger(),
+		Clock:                clk,
+		PluginNames:          []string{"bus"},
+		ChangeFeedPrincipals: []store.PrincipalID{pA.ID, pB.ID},
+		PollInterval:         20 * time.Millisecond,
+		MaxRetries:           1,
+		RetryBackoff:         time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	loopDone := make(chan struct{})
+	go func() {
+		_ = d.Run(runCtx)
+		close(loopDone)
+	}()
+
+	// Insert one message per principal so each goroutine advances its
+	// own cursor.
+	if _, _, err := st.Meta().InsertMessage(seedCtx, store.Message{Size: 1},
+		[]store.MessageMailbox{{MailboxID: mbA.ID}}); err != nil {
+		t.Fatalf("InsertMessage A: %v", err)
+	}
+	if _, _, err := st.Meta().InsertMessage(seedCtx, store.Message{Size: 1},
+		[]store.MessageMailbox{{MailboxID: mbB.ID}}); err != nil {
+		t.Fatalf("InsertMessage B: %v", err)
+	}
+
+	// Drive the FakeClock until both principals have surfaced their
+	// mail.received event.
+	deadline := time.Now().Add(3 * time.Second)
+	var sawA, sawB bool
+	for !sawA || !sawB {
+		if time.Now().After(deadline) {
+			cancel()
+			<-loopDone
+			t.Fatalf("timed out waiting for first-round deliveries (sawA=%v sawB=%v)", sawA, sawB)
+		}
+		clk.Advance(50 * time.Millisecond)
+		select {
+		case <-deliveriesA:
+			sawA = true
+		case <-deliveriesB:
+			sawB = true
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+
+	// Cancel and wait for Run (and both per-principal goroutines) to
+	// return. The shutdown defer in each runChangeFeedLoop must
+	// persist its in-memory cursor via a fresh ctx.
+	cancel()
+	<-loopDone
+
+	keyA := fmt.Sprintf("events.changefeed.%d", pA.ID)
+	keyB := fmt.Sprintf("events.changefeed.%d", pB.ID)
+	curA, err := st.Meta().GetFTSCursor(seedCtx, keyA)
+	if err != nil {
+		t.Fatalf("GetFTSCursor A: %v", err)
+	}
+	curB, err := st.Meta().GetFTSCursor(seedCtx, keyB)
+	if err != nil {
+		t.Fatalf("GetFTSCursor B: %v", err)
+	}
+	if curA == 0 {
+		t.Errorf("principal A cursor not persisted on shutdown (got 0)")
+	}
+	if curB == 0 {
+		t.Errorf("principal B cursor not persisted on shutdown (got 0)")
+	}
+	if t.Failed() {
+		return
+	}
+
+	// Restart with a fresh dispatcher on the unwrapped store. Drain
+	// any leftover deliveries first.
+	for len(deliveriesA) > 0 {
+		<-deliveriesA
+	}
+	for len(deliveriesB) > 0 {
+		<-deliveriesB
+	}
+	inv2 := newFakeInvoker()
+	deliveriesA2 := make(chan string, 16)
+	deliveriesB2 := make(chan string, 16)
+	inv2.Handle("bus", protoevents.MethodEventsPublish, func(_ context.Context, params any) error {
+		ev := params.(map[string]any)["event"].(map[string]any)
+		if ev["kind"] != string(protoevents.EventMailReceived) {
+			return nil
+		}
+		subject, _ := ev["subject"].(string)
+		payload, _ := ev["payload"].(map[string]any)
+		msgID, _ := payload["message_id"].(string)
+		switch subject {
+		case fmt.Sprintf("%d", pA.ID):
+			select {
+			case deliveriesA2 <- msgID:
+			default:
+			}
+		case fmt.Sprintf("%d", pB.ID):
+			select {
+			case deliveriesB2 <- msgID:
+			default:
+			}
+		}
+		return nil
+	})
+	d2, err := protoevents.New(protoevents.Options{
+		Store:                st,
+		Plugins:              inv2,
+		Logger:               discardLogger(),
+		Clock:                clk,
+		PluginNames:          []string{"bus"},
+		ChangeFeedPrincipals: []store.PrincipalID{pA.ID, pB.ID},
+		PollInterval:         20 * time.Millisecond,
+		MaxRetries:           1,
+		RetryBackoff:         time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("New (2): %v", err)
+	}
+
+	runCtx2, cancel2 := context.WithCancel(context.Background())
+	loopDone2 := make(chan struct{})
+	go func() {
+		_ = d2.Run(runCtx2)
+		close(loopDone2)
+	}()
+	// Give the second dispatcher several poll cycles to do nothing
+	// (no new messages, cursor honoured).
+	for i := 0; i < 8; i++ {
+		clk.Advance(50 * time.Millisecond)
+		time.Sleep(10 * time.Millisecond)
+	}
+	cancel2()
+	<-loopDone2
+
+	if got := len(deliveriesA2); got != 0 {
+		t.Errorf("principal A replayed %d events on restart (cursor lost)", got)
+	}
+	if got := len(deliveriesB2); got != 0 {
+		t.Errorf("principal B replayed %d events on restart (cursor lost)", got)
+	}
+}
+
 // TestEvent_IDIsULIDShape verifies the assigned ID is 26 chars from
 // the Crockford-Base32 alphabet, matching the ULID spec.
 func TestEvent_IDIsULIDShape(t *testing.T) {

--- a/internal/protojmap/calendars/imip/intake.go
+++ b/internal/protojmap/calendars/imip/intake.go
@@ -122,6 +122,11 @@ func (i *Intake) Run(ctx context.Context) error {
 		return errors.New("imip: Intake already running")
 	}
 	defer i.running.Store(false)
+	// Final flush on shutdown so the in-memory cursor reflects on
+	// disk even when the in-loop SetFTSCursor lost its race with
+	// ctx cancellation. Uses a fresh, short-deadline ctx so the
+	// flush itself is not cancelled the moment it starts.
+	defer i.persistCursorOnShutdown()
 
 	if seq, err := i.store.Meta().GetFTSCursor(ctx, i.opts.CursorKey); err != nil {
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
@@ -177,6 +182,25 @@ func (i *Intake) Run(ctx context.Context) error {
 				)
 			}
 		}
+	}
+}
+
+// persistCursorOnShutdown writes the in-memory cursor to the durable
+// store using a fresh ctx, so the worker's last advance lands even when
+// the run ctx is already cancelled. Called from Run's defer chain.
+func (i *Intake) persistCursorOnShutdown() {
+	seq := i.cursor.Load()
+	if seq == 0 {
+		return
+	}
+	flushCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := i.store.Meta().SetFTSCursor(flushCtx, i.opts.CursorKey, seq); err != nil {
+		i.logger.WarnContext(flushCtx, "imip: persist cursor on shutdown",
+			slog.String("key", i.opts.CursorKey),
+			slog.Uint64("seq", seq),
+			slog.Any("err", err),
+		)
 	}
 }
 

--- a/internal/protojmap/calendars/imip/intake_test.go
+++ b/internal/protojmap/calendars/imip/intake_test.go
@@ -247,12 +247,23 @@ func TestIMIP_PersistsCursorOnShutdown(t *testing.T) {
 	cancel()
 	<-done
 
+	// The intake may tick once more between the memCursor sample and
+	// the cancel, so the value flushed by the shutdown defer can be
+	// >= memCursor. Read the final in-memory cursor after Run has
+	// returned and assert against that.
+	finalMem := intake.Cursor()
+
 	persisted, err := fs.Meta().GetFTSCursor(ctx, cursorKey)
 	if err != nil {
 		t.Fatalf("GetFTSCursor post-shutdown: %v", err)
 	}
-	if persisted != memCursor {
-		t.Fatalf("post-shutdown persisted cursor = %d, in-memory cursor = %d (shutdown flush did not run)", persisted, memCursor)
+	if persisted != finalMem {
+		t.Fatalf("post-shutdown persisted cursor = %d, final in-memory cursor = %d (memCursor sample was %d) (shutdown flush did not run)",
+			persisted, finalMem, memCursor)
+	}
+	if persisted < memCursor {
+		t.Fatalf("post-shutdown persisted cursor = %d trailed observed in-memory cursor %d",
+			persisted, memCursor)
 	}
 
 	// Restart with the same cursor key against the unwrapped store.

--- a/internal/protojmap/calendars/imip/intake_test.go
+++ b/internal/protojmap/calendars/imip/intake_test.go
@@ -113,6 +113,174 @@ func deliverIMIP(t *testing.T, f *fixture, ics []byte) {
 	}
 }
 
+// shutdownFlushStore wraps a real store so the in-loop SetFTSCursor
+// path returns context.Canceled while the shutdown-path SetFTSCursor
+// (which uses a fresh background ctx) is allowed through. Models the
+// race the cursor-on-shutdown fix guards against.
+type shutdownFlushStore struct {
+	store.Store
+	failingMeta *shutdownFlushMeta
+}
+
+func (s shutdownFlushStore) Meta() store.Metadata { return s.failingMeta }
+
+type shutdownFlushMeta struct {
+	store.Metadata
+	parentCtx context.Context
+}
+
+func (m *shutdownFlushMeta) SetFTSCursor(ctx context.Context, key string, seq uint64) error {
+	if ctx == m.parentCtx {
+		return context.Canceled
+	}
+	return m.Metadata.SetFTSCursor(ctx, key, seq)
+}
+
+// TestIMIP_PersistsCursorOnShutdown asserts the worker's shutdown
+// defer flushes the in-memory cursor when the in-loop SetFTSCursor
+// lost its race with ctx cancellation. Restart with the same cursor
+// key must NOT re-apply the iMIP REQUEST (no second event row).
+func TestIMIP_PersistsCursorOnShutdown(t *testing.T) {
+	clk := clock.NewFake(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	fs, err := storesqlite.Open(context.Background(), filepath.Join(t.TempDir(), "store.db"), nil, clk)
+	if err != nil {
+		t.Fatalf("storesqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = fs.Close() })
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	ctx := context.Background()
+	p, err := fs.Meta().InsertPrincipal(ctx, store.Principal{
+		Kind:           store.PrincipalKindUser,
+		CanonicalEmail: "alice@example.test",
+	})
+	if err != nil {
+		t.Fatalf("InsertPrincipal: %v", err)
+	}
+	mb, err := fs.Meta().InsertMailbox(ctx, store.Mailbox{
+		PrincipalID: p.ID, Name: "INBOX", Attributes: store.MailboxAttrInbox,
+	})
+	if err != nil {
+		t.Fatalf("InsertMailbox: %v", err)
+	}
+
+	// Seed one iMIP REQUEST.
+	ics := []byte("BEGIN:VCALENDAR\r\n" +
+		"VERSION:2.0\r\n" +
+		"METHOD:REQUEST\r\n" +
+		"BEGIN:VEVENT\r\n" +
+		"UID:shutdown-1@example.test\r\n" +
+		"DTSTAMP:20260101T000000Z\r\n" +
+		"DTSTART:20260315T100000Z\r\n" +
+		"DTEND:20260315T110000Z\r\n" +
+		"SUMMARY:Shutdown test\r\n" +
+		"ORGANIZER:mailto:organizer@example.test\r\n" +
+		"ATTENDEE;PARTSTAT=NEEDS-ACTION:mailto:alice@example.test\r\n" +
+		"SEQUENCE:0\r\n" +
+		"END:VEVENT\r\n" +
+		"END:VCALENDAR\r\n")
+	body := []byte("From: organizer@example.test\r\n" +
+		"To: alice@example.test\r\n" +
+		"Subject: Meeting invite\r\n" +
+		"MIME-Version: 1.0\r\n" +
+		"Content-Type: text/calendar; method=REQUEST; charset=utf-8\r\n" +
+		"\r\n" +
+		string(ics))
+	ref, err := fs.Blobs().Put(ctx, strings.NewReader(string(body)))
+	if err != nil {
+		t.Fatalf("put blob: %v", err)
+	}
+	if _, _, err := fs.Meta().InsertMessage(ctx, store.Message{
+		Size: ref.Size,
+		Blob: ref,
+		Envelope: store.Envelope{
+			From:    "organizer@example.test",
+			To:      "alice@example.test",
+			Subject: "Meeting invite",
+		},
+	}, []store.MessageMailbox{{MailboxID: mb.ID}}); err != nil {
+		t.Fatalf("insert message: %v", err)
+	}
+
+	const cursorKey = "calendars-imip-shutdown-test"
+	runCtx, cancel := context.WithCancel(context.Background())
+	wrapped := shutdownFlushStore{
+		Store:       fs,
+		failingMeta: &shutdownFlushMeta{Metadata: fs.Meta(), parentCtx: runCtx},
+	}
+	intake := imip.New(imip.Options{
+		Store:        wrapped,
+		Logger:       logger,
+		Clock:        clk,
+		PollInterval: 5 * time.Millisecond,
+		CursorKey:    cursorKey,
+	})
+
+	done := make(chan error, 1)
+	go func() { done <- intake.Run(runCtx) }()
+
+	// Drive the worker until it has applied the REQUEST.
+	deadline := time.Now().Add(3 * time.Second)
+	var applied bool
+	for time.Now().Before(deadline) {
+		clk.Advance(5 * time.Millisecond)
+		rows, _ := fs.Meta().ListCalendarEvents(ctx, store.CalendarEventFilter{PrincipalID: &p.ID})
+		if len(rows) == 1 {
+			applied = true
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !applied {
+		cancel()
+		<-done
+		t.Fatalf("first intake did not apply the REQUEST")
+	}
+
+	memCursor := intake.Cursor()
+	if memCursor == 0 {
+		cancel()
+		<-done
+		t.Fatalf("first intake's in-memory cursor did not advance")
+	}
+
+	cancel()
+	<-done
+
+	persisted, err := fs.Meta().GetFTSCursor(ctx, cursorKey)
+	if err != nil {
+		t.Fatalf("GetFTSCursor post-shutdown: %v", err)
+	}
+	if persisted != memCursor {
+		t.Fatalf("post-shutdown persisted cursor = %d, in-memory cursor = %d (shutdown flush did not run)", persisted, memCursor)
+	}
+
+	// Restart with the same cursor key against the unwrapped store.
+	// The new worker must NOT re-apply the REQUEST (still exactly one
+	// row).
+	intake2 := imip.New(imip.Options{
+		Store:        fs,
+		Logger:       logger,
+		Clock:        clk,
+		PollInterval: 5 * time.Millisecond,
+		CursorKey:    cursorKey,
+	})
+	runCtx2, cancel2 := context.WithCancel(context.Background())
+	done2 := make(chan error, 1)
+	go func() { done2 <- intake2.Run(runCtx2) }()
+	for j := 0; j < 5; j++ {
+		clk.Advance(5 * time.Millisecond)
+		time.Sleep(10 * time.Millisecond)
+	}
+	cancel2()
+	<-done2
+
+	rows, _ := fs.Meta().ListCalendarEvents(ctx, store.CalendarEventFilter{PrincipalID: &p.ID})
+	if len(rows) != 1 {
+		t.Fatalf("after restart events = %d, want 1 (no double application)", len(rows))
+	}
+}
+
 func TestIMIP_Request_CreatesEventOnDefaultCalendar(t *testing.T) {
 	f := newFixture(t)
 	ics := []byte("BEGIN:VCALENDAR\r\n" +

--- a/internal/storefts/worker.go
+++ b/internal/storefts/worker.go
@@ -171,9 +171,24 @@ func (w *Worker) Run(ctx context.Context) error {
 	for {
 		if err := ctx.Err(); err != nil {
 			// Final flush on shutdown so in-flight changes land in the
-			// index. Use a fresh context so the flush itself is not
-			// cancelled the moment it starts.
+			// index AND the durable cursor reflects the in-memory
+			// advance. Use a fresh context so the flush itself is not
+			// cancelled the moment it starts. Persist the cursor
+			// BEFORE the index commit: if the cursor write fails, we
+			// must not commit the index past it (a restart would then
+			// re-read from a stale cursor while the index already
+			// contains the newer docs; IndexMessage is idempotent so
+			// the worst case is a small replay, but we prefer the
+			// invariant that the cursor never trails the index).
 			flushCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			if seq := w.cursor.Load(); seq > 0 {
+				if err := w.store.Meta().SetFTSCursor(flushCtx, w.opts.CursorKey, seq); err != nil {
+					w.logger.Warn("storefts: persist cursor on shutdown",
+						"key", w.opts.CursorKey,
+						"seq", seq,
+						"err", err.Error())
+				}
+			}
 			_ = w.idx.Commit(flushCtx)
 			cancel()
 			return nil

--- a/internal/storefts/worker_test.go
+++ b/internal/storefts/worker_test.go
@@ -516,12 +516,25 @@ func TestWorker_PersistsCursorOnShutdown(t *testing.T) {
 	cancel()
 	<-done
 
+	// Capture the final in-memory cursor after Run has returned. The
+	// worker may have ticked again between the memCursor snapshot and
+	// the cancel, so the value flushed by the shutdown defer can be
+	// >= memCursor. The invariant we are guarding is that the
+	// persisted cursor reflects the final in-memory advance, not
+	// merely the one we observed earlier.
+	finalMem := w.Cursor()
+
 	persisted, err := fake.Meta().GetFTSCursor(seedCtx, cursorKey)
 	if err != nil {
 		t.Fatalf("GetFTSCursor post-shutdown: %v", err)
 	}
-	if persisted != memCursor {
-		t.Fatalf("post-shutdown persisted cursor = %d, in-memory cursor = %d", persisted, memCursor)
+	if persisted != finalMem {
+		t.Fatalf("post-shutdown persisted cursor = %d, final in-memory cursor = %d (memCursor snapshot was %d)",
+			persisted, finalMem, memCursor)
+	}
+	if persisted < memCursor {
+		t.Fatalf("post-shutdown persisted cursor = %d trailed observed in-memory cursor %d",
+			persisted, memCursor)
 	}
 
 	// Restart with a fresh worker and a fresh (non-wrapped) store.
@@ -537,10 +550,10 @@ func TestWorker_PersistsCursorOnShutdown(t *testing.T) {
 	for w2.Cursor() == 0 && time.Now().Before(deadline) {
 		clk.Advance(10 * time.Millisecond)
 	}
-	if w2.Cursor() != memCursor {
+	if w2.Cursor() != finalMem {
 		cancel2()
 		<-done2
-		t.Fatalf("restarted worker cursor = %d, want %d (no replay)", w2.Cursor(), memCursor)
+		t.Fatalf("restarted worker cursor = %d, want %d (no replay)", w2.Cursor(), finalMem)
 	}
 	cancel2()
 	<-done2

--- a/internal/storefts/worker_test.go
+++ b/internal/storefts/worker_test.go
@@ -381,6 +381,171 @@ func TestWorker_CursorPersistsAcrossRestart(t *testing.T) {
 	<-done2
 }
 
+// shutdownFlushStore wraps a real store so the in-loop SetFTSCursor
+// path returns context.Canceled while the shutdown-path SetFTSCursor
+// (which uses a fresh, non-cancelled context) is allowed through.
+// This isolates the cursor-persistence-on-shutdown invariant: with the
+// fix, the worker writes the advanced cursor on its way out via a
+// fresh ctx and the persisted value matches the in-memory advance;
+// without the fix, every SetFTSCursor would carry the cancelled ctx
+// and the persisted cursor would lag behind.
+type shutdownFlushStore struct {
+	store.Store
+	failingMeta *shutdownFlushMeta
+}
+
+func (s shutdownFlushStore) Meta() store.Metadata { return s.failingMeta }
+
+type shutdownFlushMeta struct {
+	store.Metadata
+	parentCtx context.Context
+}
+
+func (m *shutdownFlushMeta) SetFTSCursor(ctx context.Context, key string, seq uint64) error {
+	// Reject any write whose ctx descends from the worker's main run
+	// ctx. The shutdown path uses a fresh background ctx so its writes
+	// land on the embedded store.
+	if ctx == m.parentCtx || ctxIsChildOf(ctx, m.parentCtx) {
+		return context.Canceled
+	}
+	return m.Metadata.SetFTSCursor(ctx, key, seq)
+}
+
+// ctxIsChildOf reports whether child was derived from parent. We
+// compare via context.Cause's parent chain by walking until we hit a
+// matching pointer. The standard library does not expose the parent
+// pointer, so we approximate: the worker stores a cancellable ctx and
+// derives no further ctx from it; the in-loop SetFTSCursor receives
+// that exact ctx. The shutdown path constructs a fresh
+// context.WithTimeout(context.Background(), ...) which trivially is
+// not the parent. Pointer-equality on the supplied ctx is therefore
+// sufficient for this test.
+func ctxIsChildOf(child, parent context.Context) bool {
+	return child == parent
+}
+
+// TestWorker_PersistsCursorOnShutdown asserts that when the in-loop
+// SetFTSCursor would race with ctx cancellation (modelled here by a
+// wrapper that fails the in-loop call but admits the shutdown-path
+// call), the worker still durably persists the advanced cursor before
+// Run returns. A subsequent fresh worker hydrates from the persisted
+// cursor and does not re-process the same change.
+func TestWorker_PersistsCursorOnShutdown(t *testing.T) {
+	clk := clock.NewFake(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	fake, err := storesqlite.OpenWithRand(context.Background(), dbPath, nil, clk, rand.Reader)
+	if err != nil {
+		t.Fatalf("storesqlite.OpenWithRand: %v", err)
+	}
+	t.Cleanup(func() { _ = fake.Close() })
+	idx, err := storefts.New(t.TempDir(), nil, clk)
+	if err != nil {
+		t.Fatalf("storefts.New: %v", err)
+	}
+	t.Cleanup(func() { _ = idx.Close() })
+
+	seedCtx := context.Background()
+	p, err := fake.Meta().InsertPrincipal(seedCtx, store.Principal{
+		Kind: store.PrincipalKindUser, CanonicalEmail: "shutdown@example.test",
+	})
+	if err != nil {
+		t.Fatalf("InsertPrincipal: %v", err)
+	}
+	mb, err := fake.Meta().InsertMailbox(seedCtx, store.Mailbox{PrincipalID: p.ID, Name: "INBOX"})
+	if err != nil {
+		t.Fatalf("InsertMailbox: %v", err)
+	}
+	for i := 0; i < 5; i++ {
+		raw := fmt.Sprintf("Subject: shutdown-%d\r\n\r\nbody\r\n", i)
+		ref, err := fake.Blobs().Put(seedCtx, strings.NewReader(raw))
+		if err != nil {
+			t.Fatalf("Put: %v", err)
+		}
+		if _, _, err := fake.Meta().InsertMessage(seedCtx, store.Message{Blob: ref, Size: ref.Size},
+			[]store.MessageMailbox{{MailboxID: mb.ID}}); err != nil {
+			t.Fatalf("InsertMessage: %v", err)
+		}
+	}
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	wrappedMeta := &shutdownFlushMeta{Metadata: fake.Meta(), parentCtx: runCtx}
+	wrapped := shutdownFlushStore{Store: fake, failingMeta: wrappedMeta}
+
+	const cursorKey = "fts-shutdown-flush-test"
+	w := storefts.NewWorker(idx, wrapped, stringExtractor{}, nil, clk,
+		storefts.WorkerOptions{CursorKey: cursorKey})
+	done := make(chan error, 1)
+	go func() { done <- w.Run(runCtx) }()
+
+	// Drive the worker through one flush so its in-memory cursor
+	// advances. The wrapped SetFTSCursor will refuse the in-loop call,
+	// so the persisted cursor stays at zero.
+	flushSig := w.CurrentFlushSignal()
+	clk.Advance(storefts.DefaultFlushInterval + 10*time.Millisecond)
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	select {
+	case <-flushSig:
+	case <-waitCtx.Done():
+		waitCancel()
+		cancel()
+		<-done
+		t.Fatalf("wait flush: %v", waitCtx.Err())
+	}
+	waitCancel()
+
+	memCursor := w.Cursor()
+	if memCursor == 0 {
+		cancel()
+		<-done
+		t.Fatalf("in-memory cursor did not advance")
+	}
+
+	// Pre-shutdown: the wrapper rejected every in-loop write, so the
+	// persisted cursor is still zero. (Verifies the test's wrapper
+	// actually exhibits the race we are guarding against.)
+	preShutdown, err := fake.Meta().GetFTSCursor(seedCtx, cursorKey)
+	if err != nil {
+		t.Fatalf("GetFTSCursor pre-shutdown: %v", err)
+	}
+	if preShutdown != 0 {
+		t.Logf("note: persisted cursor was %d pre-shutdown (wrapper let a write through)", preShutdown)
+	}
+
+	// Cancel and wait for Run to return. The shutdown path must
+	// persist the in-memory advance.
+	cancel()
+	<-done
+
+	persisted, err := fake.Meta().GetFTSCursor(seedCtx, cursorKey)
+	if err != nil {
+		t.Fatalf("GetFTSCursor post-shutdown: %v", err)
+	}
+	if persisted != memCursor {
+		t.Fatalf("post-shutdown persisted cursor = %d, in-memory cursor = %d", persisted, memCursor)
+	}
+
+	// Restart with a fresh worker and a fresh (non-wrapped) store.
+	// Drive its hydration; it must begin at the persisted cursor and
+	// must NOT re-index the seeded messages.
+	w2 := storefts.NewWorker(idx, fake, stringExtractor{}, nil, clk,
+		storefts.WorkerOptions{CursorKey: cursorKey})
+	runCtx2, cancel2 := context.WithCancel(context.Background())
+	done2 := make(chan error, 1)
+	go func() { done2 <- w2.Run(runCtx2) }()
+	clk.Advance(storefts.DefaultFlushInterval + 10*time.Millisecond)
+	deadline := time.Now().Add(2 * time.Second)
+	for w2.Cursor() == 0 && time.Now().Before(deadline) {
+		clk.Advance(10 * time.Millisecond)
+	}
+	if w2.Cursor() != memCursor {
+		cancel2()
+		<-done2
+		t.Fatalf("restarted worker cursor = %d, want %d (no replay)", w2.Cursor(), memCursor)
+	}
+	cancel2()
+	<-done2
+}
+
 // TestWorker_LagCharacteristics reports the observed p50/p99 indexing
 // lag across a small synthetic workload. Not a correctness gate; it
 // exists so future changes to the worker's scheduling are surfaced in

--- a/internal/webpush/dispatcher.go
+++ b/internal/webpush/dispatcher.go
@@ -257,6 +257,11 @@ func (d *Dispatcher) Run(ctx context.Context) error {
 		return errors.New("webpush: dispatcher already running")
 	}
 	defer d.running.Store(false)
+	// Final flush on shutdown so the in-memory cursor lands on disk
+	// even when the in-loop SetFTSCursor lost its race with ctx
+	// cancellation. Uses a fresh, short-deadline ctx so the flush
+	// itself is not cancelled the moment it starts.
+	defer d.persistCursorOnShutdown()
 
 	if !d.vapid.Configured() {
 		d.logger.LogAttrs(ctx, slog.LevelInfo,
@@ -311,6 +316,25 @@ func (d *Dispatcher) Close(ctx context.Context) error {
 	_ = ctx
 	d.stopAllCoalesce()
 	return nil
+}
+
+// persistCursorOnShutdown writes the in-memory cursor to the durable
+// store using a fresh ctx, so the worker's last advance lands even
+// when the run ctx is already cancelled. Called from Run's defer
+// chain.
+func (d *Dispatcher) persistCursorOnShutdown() {
+	seq := d.cursor.Load()
+	if seq == 0 {
+		return
+	}
+	flushCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := d.store.Meta().SetFTSCursor(flushCtx, d.cursorKey, seq); err != nil {
+		d.logger.LogAttrs(flushCtx, slog.LevelWarn, "webpush: persist cursor on shutdown",
+			slog.String("key", d.cursorKey),
+			slog.Uint64("seq", seq),
+			slog.String("err", err.Error()))
+	}
 }
 
 // tick reads one batch of change-feed entries, fans the relevant

--- a/internal/webpush/dispatcher_test.go
+++ b/internal/webpush/dispatcher_test.go
@@ -370,6 +370,194 @@ func TestDispatcher_TypeFilter_SkipsNonMatching(t *testing.T) {
 	}
 }
 
+// shutdownFlushStore wraps a real store so the in-loop SetFTSCursor
+// path returns context.Canceled while the shutdown-path SetFTSCursor
+// (which uses a fresh background ctx) is allowed through. Models the
+// race the cursor-on-shutdown fix guards against.
+type shutdownFlushStore struct {
+	store.Store
+	failingMeta *shutdownFlushMeta
+}
+
+func (s shutdownFlushStore) Meta() store.Metadata { return s.failingMeta }
+
+type shutdownFlushMeta struct {
+	store.Metadata
+	parentCtx context.Context
+}
+
+func (m *shutdownFlushMeta) SetFTSCursor(ctx context.Context, key string, seq uint64) error {
+	if ctx == m.parentCtx {
+		return context.Canceled
+	}
+	return m.Metadata.SetFTSCursor(ctx, key, seq)
+}
+
+// TestDispatcher_PersistsCursorOnShutdown asserts that the Run loop's
+// shutdown defer flushes the in-memory cursor to disk when the
+// in-loop SetFTSCursor lost its race with ctx cancellation. A restart
+// with the same cursor key must NOT re-deliver the message that was
+// already pushed before shutdown.
+func TestDispatcher_PersistsCursorOnShutdown(t *testing.T) {
+	t.Parallel()
+	clk := clock.NewFake(time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC))
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	st, err := storesqlite.OpenWithRand(context.Background(), dbPath, nil, clk, rand.Reader)
+	if err != nil {
+		t.Fatalf("storesqlite.OpenWithRand: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	priv, err := ecdh.P256().GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("recipient key: %v", err)
+	}
+	auth := make([]byte, authSecretLen)
+	rand.Read(auth)
+
+	kp, err := vapid.Generate(nil)
+	if err != nil {
+		t.Fatalf("vapid.Generate: %v", err)
+	}
+	mgr := vapid.NewWithKey(kp)
+
+	gw := newGateway(http.StatusCreated)
+	t.Cleanup(gw.Close)
+
+	seedCtx := context.Background()
+	p, err := st.Meta().InsertPrincipal(seedCtx, store.Principal{
+		Kind:           store.PrincipalKindUser,
+		CanonicalEmail: "alice@example.test",
+	})
+	if err != nil {
+		t.Fatalf("InsertPrincipal: %v", err)
+	}
+	mb, err := st.Meta().InsertMailbox(seedCtx, store.Mailbox{
+		PrincipalID: p.ID,
+		Name:        "INBOX",
+	})
+	if err != nil {
+		t.Fatalf("InsertMailbox: %v", err)
+	}
+	if _, err := st.Meta().InsertPushSubscription(seedCtx, store.PushSubscription{
+		PrincipalID:    p.ID,
+		DeviceClientID: "test-device",
+		URL:            gw.URL(),
+		P256DH:         priv.PublicKey().Bytes(),
+		Auth:           auth,
+		Verified:       true,
+		Types:          []string{"Email"},
+	}); err != nil {
+		t.Fatalf("InsertPushSubscription: %v", err)
+	}
+
+	const cursorKey = "webpush-shutdown-flush-test"
+	runCtx, cancel := context.WithCancel(context.Background())
+	wrapped := shutdownFlushStore{
+		Store:       st,
+		failingMeta: &shutdownFlushMeta{Metadata: st.Meta(), parentCtx: runCtx},
+	}
+	disp, err := New(Options{
+		Store:        wrapped,
+		VAPID:        mgr,
+		Clock:        clk,
+		Logger:       slog.Default(),
+		HTTPDoer:     gw.srv.Client(),
+		Hostname:     "example.test",
+		PollInterval: 20 * time.Millisecond,
+		CursorKey:    cursorKey,
+	})
+	if err != nil {
+		t.Fatalf("webpush.New: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- disp.Run(runCtx) }()
+
+	// Insert one message so the change-feed reader has something to
+	// process.
+	ref, err := st.Blobs().Put(seedCtx, strings.NewReader("body"))
+	if err != nil {
+		t.Fatalf("Blobs.Put: %v", err)
+	}
+	if _, _, err := st.Meta().InsertMessage(seedCtx, store.Message{
+		Blob: ref, Size: ref.Size,
+		Envelope: store.Envelope{From: "Bob <bob@example.test>", Subject: "hello"},
+	}, []store.MessageMailbox{{MailboxID: mb.ID}}); err != nil {
+		t.Fatalf("InsertMessage: %v", err)
+	}
+
+	// Drive Run until the gateway has seen a delivery.
+	deadline := time.Now().Add(3 * time.Second)
+	for len(gw.Calls()) == 0 {
+		if time.Now().After(deadline) {
+			cancel()
+			<-done
+			t.Fatalf("first dispatcher did not deliver the push")
+		}
+		clk.Advance(20 * time.Millisecond)
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	memCursor := disp.cursor.Load()
+	if memCursor == 0 {
+		cancel()
+		<-done
+		t.Fatalf("dispatcher in-memory cursor did not advance")
+	}
+
+	cancel()
+	<-done
+
+	persisted, err := st.Meta().GetFTSCursor(seedCtx, cursorKey)
+	if err != nil {
+		t.Fatalf("GetFTSCursor post-shutdown: %v", err)
+	}
+	// The in-memory cursor we sampled before cancel is a lower
+	// bound: the dispatcher may have ticked further while we were
+	// preparing to cancel. The shutdown flush must persist at least
+	// memCursor (and may persist more); without the fix, persisted
+	// would be 0.
+	finalMemCursor := disp.cursor.Load()
+	if persisted < memCursor {
+		t.Fatalf("post-shutdown persisted cursor = %d, sampled in-memory = %d (shutdown flush did not run)", persisted, memCursor)
+	}
+	if persisted != finalMemCursor {
+		t.Fatalf("post-shutdown persisted cursor = %d, final in-memory = %d (shutdown flush did not catch the latest advance)", persisted, finalMemCursor)
+	}
+
+	deliveriesAfterFirst := len(gw.Calls())
+
+	// Restart with the same cursor key against the unwrapped store.
+	// The new dispatcher must NOT re-deliver the existing message.
+	disp2, err := New(Options{
+		Store:        st,
+		VAPID:        mgr,
+		Clock:        clk,
+		Logger:       slog.Default(),
+		HTTPDoer:     gw.srv.Client(),
+		Hostname:     "example.test",
+		PollInterval: 20 * time.Millisecond,
+		CursorKey:    cursorKey,
+	})
+	if err != nil {
+		t.Fatalf("webpush.New (2): %v", err)
+	}
+	runCtx2, cancel2 := context.WithCancel(context.Background())
+	done2 := make(chan error, 1)
+	go func() { done2 <- disp2.Run(runCtx2) }()
+	for j := 0; j < 8; j++ {
+		clk.Advance(20 * time.Millisecond)
+		time.Sleep(10 * time.Millisecond)
+	}
+	cancel2()
+	<-done2
+
+	if got := len(gw.Calls()); got != deliveriesAfterFirst {
+		t.Fatalf("after restart deliveries = %d, want %d (no double delivery)", got, deliveriesAfterFirst)
+	}
+}
+
 // TestDispatcher_RunBlocksWithoutVAPID exercises the unconfigured-VAPID
 // short-circuit: the dispatcher's Run stays alive on ctx but never
 // reads the change feed.


### PR DESCRIPTION
## Summary

Five workers shared the same race that PR #79 already fixed in `protowebhook`: an in-memory `atomic.Uint64` cursor advanced on every tick, but the durable `SetFTSCursor` call inside the loop ran with the worker's ctx and so failed silently as soon as the parent cancelled. On a clean shutdown the in-memory advance was therefore lost, and a restart would replay every change between the last successful disk write and the cancellation.

The five workers fixed in this PR:

- `internal/storefts` — full-text index ingest worker
- `internal/maildmarc` — DMARC report intake
- `internal/protojmap/calendars/imip` — iMIP intake
- `internal/protoevents` — per-principal change-feed dispatcher
- `internal/webpush` — Web Push dispatcher

Each now has a defer in `Run` that captures the latest in-memory cursor and writes it back through a fresh, short-deadline context so the flush itself cannot be cancelled by the same shutdown signal that ended the loop.

## Test plan

- [x] New `TestX_PersistsCursorOnShutdown` per worker, run 20x with `-race` locally
- [x] All five existing test suites still green
- [x] `go vet`, `staticcheck`, pre-commit pass

re #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)