### PR TITLE
webpush: fix race in TestDispatcher_PersistsCursorOnShutdown

### DIFF
--- a/internal/webpush/dispatcher_test.go
+++ b/internal/webpush/dispatcher_test.go
@@ -487,24 +487,29 @@ func TestDispatcher_PersistsCursorOnShutdown(t *testing.T) {
 		t.Fatalf("InsertMessage: %v", err)
 	}
 
-	// Drive Run until the gateway has seen a delivery.
-	deadline := time.Now().Add(3 * time.Second)
-	for len(gw.Calls()) == 0 {
+	// Drive Run until the dispatcher's tick has fully completed for at
+	// least one delivery: cursor advanced AND the gateway saw the call.
+	// Waiting on cursor advance only is not enough — we want to confirm
+	// the push really left the dispatcher. Waiting on gw.Calls() only is
+	// not enough either, because deliver is invoked from processChange
+	// BEFORE the cursor.Store at the end of tick, so the gateway can see
+	// the call before the cursor moves.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if disp.cursor.Load() > 0 && len(gw.Calls()) > 0 {
+			break
+		}
 		if time.Now().After(deadline) {
 			cancel()
 			<-done
-			t.Fatalf("first dispatcher did not deliver the push")
+			t.Fatalf("first dispatcher did not deliver and advance cursor (gw.Calls=%d, cursor=%d)",
+				len(gw.Calls()), disp.cursor.Load())
 		}
 		clk.Advance(20 * time.Millisecond)
 		time.Sleep(10 * time.Millisecond)
 	}
 
 	memCursor := disp.cursor.Load()
-	if memCursor == 0 {
-		cancel()
-		<-done
-		t.Fatalf("dispatcher in-memory cursor did not advance")
-	}
 
 	cancel()
 	<-done


### PR DESCRIPTION
## Summary

Post-merge main CI on `d41a629` failed in pre-commit's `go test -race` step:

```
--- FAIL: TestDispatcher_PersistsCursorOnShutdown
    dispatcher_test.go:506: dispatcher in-memory cursor did not advance
```

The test waited for `gw.Calls() != []` and then immediately read `disp.cursor.Load()`. But `deliver` is called from `processChange` inside the for-loop body in `tick`, before the `cursor.Store(maxSeq)` at the end of `tick`. On a slow CI runner the test sampled the cursor in the window between the HTTP POST returning and the cursor write, finding it still 0.

Fix: wait for both `gw.Calls() > 0` AND `cursor.Load() > 0` before proceeding. Also bumped the deadline 3s -> 5s.

## Test plan

- [x] `go test -race -count=20 ./internal/webpush/` — passes locally
- [x] pre-commit -race lane passes locally

re #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)