### PR TITLE
suite(compose): fix inlined image issues (re #83)

### DIFF
--- a/web/apps/suite/src/lib/compose/ComposeToolbar.svelte
+++ b/web/apps/suite/src/lib/compose/ComposeToolbar.svelte
@@ -62,14 +62,14 @@
       });
       return;
     }
-    // Insert each picked image sequentially so the editor's cursor
-    // advances between insertions and every image receives its own
-    // <img> node + unique cid. A Promise.all would interleave
-    // addInlineImage calls and applyImage dispatches in unpredictable
-    // order.
+    // Insert each picked image sequentially using the two-phase approach
+    // (startInlineImage + uploadInlineImage) so the thumbnail appears in
+    // the editor immediately before the JMAP round-trip begins (issue #83).
+    // Serial insertion keeps ProseMirror cursor positions predictable.
+    const pending: Array<{ key: string; objectURL: string; file: File }> = [];
     for (const file of images) {
-      const result = await compose.addInlineImage(file);
-      if (!result) {
+      const started = compose.startInlineImage(file);
+      if (!started) {
         toast.show({
           message: `Image upload failed: ${file.name}`,
           kind: 'error',
@@ -77,10 +77,27 @@
         });
         continue;
       }
-      // Use the blob: URL for in-editor preview; persistDraft and
-      // send() rewrite it to cid:<cid> before the message goes to JMAP.
-      applyImage(view, result.objectURL, file.name);
+      // Insert immediately so the editor shows the thumbnail at once.
+      // The blob: URL is rewritten to cid: on send/save.
+      applyImage(view, started.objectURL, file.name);
+      pending.push({ key: started.key, objectURL: started.objectURL, file });
     }
+    // Run uploads in parallel; retract placeholder on failure.
+    await Promise.all(
+      pending.map(async ({ key, objectURL, file: f }) => {
+        const errMsg = await compose.uploadInlineImage(key, f);
+        if (errMsg) {
+          toast.show({
+            message: `Image upload failed: ${f.name}`,
+            kind: 'error',
+            timeoutMs: 4000,
+          });
+          // Remove the in-editor placeholder so the body stays consistent.
+          const { removeImageBySrc } = await import('./editor');
+          removeImageBySrc(view, objectURL);
+        }
+      }),
+    );
   }
 </script>
 

--- a/web/apps/suite/src/lib/compose/ComposeWindow.svelte
+++ b/web/apps/suite/src/lib/compose/ComposeWindow.svelte
@@ -153,6 +153,45 @@
   let editorView = $state<EditorView | null>(null);
   let active = $state<ActiveState>(EMPTY_ACTIVE);
 
+  /**
+   * Set of blob: objectURLs for inline images currently in 'uploading' state.
+   * Passed to RichEditor so it can render those images with a greyed-out
+   * overlay while the JMAP blob upload is in flight (issue #83).
+   */
+  let uploadingSrcs = $derived(
+    new Set(
+      compose.attachments
+        .filter((a) => a.inline && a.status === 'uploading' && a.objectURL)
+        .map((a) => a.objectURL as string),
+    ),
+  );
+
+  /**
+   * Non-inline attachments shown in the chip strip. Inline images are NOT
+   * listed here — they are already visible in the editor body (issue #83).
+   */
+  let nonInlineAttachments = $derived(
+    compose.attachments.filter((a) => !a.inline),
+  );
+
+  /**
+   * Called by RichEditor when the user removes an image node from the
+   * ProseMirror document (Delete/Backspace/Cut). We find the corresponding
+   * attachment by its objectURL or cid: src and remove it from
+   * compose.attachments so it is not included in the outbound MIME structure
+   * (issue #83).
+   */
+  function onImageRemoved(src: string): void {
+    const att = compose.attachments.find(
+      (a) =>
+        a.inline &&
+        (a.objectURL === src || (a.cid && `cid:${a.cid}` === src)),
+    );
+    if (att) {
+      compose.removeAttachment(att.key);
+    }
+  }
+
   // File picker — triggered by the toolbar Attach button. Always attaches
   // (never inlines) per REQ-ATT-01.
   let fileInput = $state<HTMLInputElement | null>(null);
@@ -619,6 +658,8 @@
                 onUpdate={onEditorUpdate}
                 onActiveChange={(a) => (active = a)}
                 onView={(v) => (editorView = v)}
+                {onImageRemoved}
+                {uploadingSrcs}
               />
             {/key}
             <!-- svelte-ignore a11y_no_static_element_interactions -->
@@ -664,93 +705,43 @@
         </div>
       </div>
 
-      {#if compose.attachments.length > 0}
-        {@const attaches = compose.attachments.filter((a) => !a.inline)}
-        {@const inlines = compose.attachments.filter((a) => a.inline)}
-
-        {#if attaches.length > 0}
-          <div class="row attachments-row">
-            <span class="label">{t('compose.attached')}</span>
-            <ul class="attachments-list">
-              {#each attaches as a (a.key)}
-                <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-                <li
-                  class:failed={a.status === 'failed'}
-                  draggable="true"
-                  ondragstart={(e) => onChipDragStart(e, a.key)}
-                >
-                  <span class="att-name">{a.name}</span>
-                  <span class="att-size">{formatSize(a.size)}</span>
-                  <span class="att-status">
-                    {#if a.status === 'uploading'}
-                      Uploading…
-                    {:else if a.status === 'failed'}
-                      {a.error ?? 'Upload failed'}
-                    {:else}
-                      Ready
-                    {/if}
-                  </span>
-                  <button
-                    type="button"
-                    class="att-remove"
-                    aria-label="Remove {a.name}"
-                    onclick={() => compose.removeAttachment(a.key)}
-                  >
-                    ×
-                  </button>
-                </li>
-              {/each}
-            </ul>
-          </div>
-        {/if}
-
-        {#if inlines.length > 0}
-          <div class="row attachments-row">
-            <span class="label">Inline</span>
-            <ul class="attachments-list">
-              {#each inlines as a (a.key)}
-                <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-                <li
-                  class:failed={a.status === 'failed'}
-                  draggable="true"
-                  ondragstart={(e) => onChipDragStart(e, a.key)}
-                >
-                  {#if a.objectURL}
-                    <img class="att-thumb" src={a.objectURL} alt={a.name} />
+      <!-- Inline images are visible in the editor body and do NOT appear in
+           the attachment chip strip (issue #83). Only non-inline file
+           attachments are listed here. -->
+      {#if nonInlineAttachments.length > 0}
+        <div class="row attachments-row">
+          <span class="label">{t('compose.attached')}</span>
+          <ul class="attachments-list">
+            {#each nonInlineAttachments as a (a.key)}
+              <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+              <li
+                class:failed={a.status === 'failed'}
+                draggable="true"
+                ondragstart={(e) => onChipDragStart(e, a.key)}
+              >
+                <span class="att-name">{a.name}</span>
+                <span class="att-size">{formatSize(a.size)}</span>
+                <span class="att-status">
+                  {#if a.status === 'uploading'}
+                    Uploading…
+                  {:else if a.status === 'failed'}
+                    {a.error ?? 'Upload failed'}
+                  {:else}
+                    Ready
                   {/if}
-                  <span class="att-name">{a.name}</span>
-                  <span class="att-size">{formatSize(a.size)}</span>
-                  <span class="att-status">
-                    {#if a.status === 'uploading'}
-                      Uploading…
-                    {:else if a.status === 'failed'}
-                      {a.error ?? 'Upload failed'}
-                    {:else}
-                      Inline
-                    {/if}
-                  </span>
-                  <button
-                    type="button"
-                    class="att-move"
-                    aria-label={t('compose.moveToAttachments')}
-                    title={t('compose.moveToAttachments')}
-                    onclick={() => void compose.flipToAttachment(a.key)}
-                  >
-                    &#x2913;
-                  </button>
-                  <button
-                    type="button"
-                    class="att-remove"
-                    aria-label="Remove {a.name}"
-                    onclick={() => compose.removeAttachment(a.key)}
-                  >
-                    ×
-                  </button>
-                </li>
-              {/each}
-            </ul>
-          </div>
-        {/if}
+                </span>
+                <button
+                  type="button"
+                  class="att-remove"
+                  aria-label="Remove {a.name}"
+                  onclick={() => compose.removeAttachment(a.key)}
+                >
+                  ×
+                </button>
+              </li>
+            {/each}
+          </ul>
+        </div>
       {/if}
     </div>
 
@@ -1112,17 +1103,6 @@
     border-radius: var(--radius-md);
     cursor: grab;
   }
-  /* Inline chips get a thumbnail column */
-  .attachments-list li:has(.att-thumb) {
-    grid-template-columns: auto 1fr auto auto auto auto;
-  }
-  .att-thumb {
-    width: 32px;
-    height: 32px;
-    object-fit: cover;
-    border-radius: var(--radius-sm);
-    flex-shrink: 0;
-  }
   .attachments-list li.failed {
     border-color: var(--support-error);
   }
@@ -1140,18 +1120,6 @@
   }
   .attachments-list li.failed .att-status {
     color: var(--support-error);
-  }
-  .att-move {
-    width: 24px;
-    height: 24px;
-    color: var(--text-helper);
-    border-radius: var(--radius-pill);
-    line-height: 1;
-    font-size: 14px;
-  }
-  .att-move:hover {
-    background: var(--layer-03);
-    color: var(--text-primary);
   }
   .att-remove {
     width: 24px;

--- a/web/apps/suite/src/lib/compose/RichEditor.svelte
+++ b/web/apps/suite/src/lib/compose/RichEditor.svelte
@@ -15,7 +15,15 @@
     onUpdate?: (html: string, text: string) => void;
     onActiveChange?: (active: ActiveState) => void;
     onView?: (view: EditorView | null) => void;
+    /** Called when the user removes an image from the editor (issue #83). */
+    onImageRemoved?: (src: string) => void;
     autofocus?: boolean;
+    /**
+     * Set of blob: objectURLs currently in the 'uploading' state (issue #83).
+     * The editor renders those image nodes with a greyed-out overlay so the
+     * user knows the upload is still in progress.
+     */
+    uploadingSrcs?: ReadonlySet<string>;
   }
 
   let {
@@ -23,10 +31,13 @@
     onUpdate,
     onActiveChange,
     onView,
+    onImageRemoved,
     autofocus = false,
+    uploadingSrcs = new Set<string>(),
   }: Props = $props();
 
   let host = $state<HTMLDivElement | null>(null);
+  let currentView = $state<EditorView | null>(null);
 
   $effect(() => {
     if (!host) return;
@@ -36,16 +47,41 @@
         onUpdate?.(docToHtml(state.doc), docToText(state.doc));
         onActiveChange?.(computeActive(state));
       },
+      onImageRemoved,
     });
+    currentView = view;
     onView?.(view);
     onActiveChange?.(EMPTY_ACTIVE);
     if (autofocus) {
       requestAnimationFrame(() => view.focus());
     }
     return () => {
+      currentView = null;
       onView?.(null);
       view.destroy();
     };
+  });
+
+  /**
+   * Apply/remove the 'img-uploading' CSS class on image elements in the
+   * ProseMirror editor DOM when their upload status changes (issue #83).
+   * We operate directly on the live DOM because ProseMirror does not
+   * re-render nodes unless the document changes; this is a visual-only
+   * overlay that does not affect the document model.
+   */
+  $effect(() => {
+    const view = currentView;
+    if (!view) return;
+    const srcs = uploadingSrcs;
+    const editorDom = view.dom;
+    const imgs = editorDom.querySelectorAll<HTMLImageElement>('img');
+    for (const img of imgs) {
+      if (srcs.has(img.src)) {
+        img.classList.add('img-uploading');
+      } else {
+        img.classList.remove('img-uploading');
+      }
+    }
   });
 </script>
 
@@ -110,5 +146,14 @@
   .rich-editor :global(.ProseMirror img) {
     max-width: 100%;
     height: auto;
+  }
+
+  /* Upload progress overlay for inline images (issue #83).
+     img-uploading is applied imperatively via the $effect above while
+     the corresponding ComposeAttachment.status === 'uploading'.
+     The image fades to greyscale so the user sees that upload is in flight. */
+  .rich-editor :global(.ProseMirror img.img-uploading) {
+    opacity: 0.4;
+    filter: grayscale(60%);
   }
 </style>

--- a/web/apps/suite/src/lib/compose/editor.ts
+++ b/web/apps/suite/src/lib/compose/editor.ts
@@ -4,6 +4,12 @@
  *
  * The Svelte wrapper (RichEditor.svelte) keeps a thin reactive bridge for
  * the toolbar; everything imperative lives here.
+ *
+ * Image lifecycle hooks (issue #83):
+ *   onImageRemoved — called with the src of each image node that disappears
+ *   from the document in a transaction (user Delete/Backspace/Cut). The
+ *   compose store uses this to drop the corresponding attachment record so
+ *   deleted inline images do not appear in the outbound MIME part list.
  */
 
 import {
@@ -145,11 +151,28 @@ function composeKeymap() {
   });
 }
 
+/**
+ * Collect all `src` attribute values of image nodes in a document.
+ * Used to diff before/after states to detect removed images (issue #83).
+ */
+export function collectImageSrcs(doc: Node): Set<string> {
+  const srcs = new Set<string>();
+  doc.descendants((node) => {
+    if (node.type.name === 'image') {
+      const src = node.attrs.src as string | undefined;
+      if (src) srcs.add(src);
+    }
+  });
+  return srcs;
+}
+
 export function createComposeEditor(
   target: HTMLElement,
   options: {
     initialHtml: string;
     onChange: (state: EditorStateType) => void;
+    /** Called with the src of each image node removed from the doc (issue #83). */
+    onImageRemoved?: (src: string) => void;
   },
 ): EditorView {
   const doc = htmlToDoc(options.initialHtml);
@@ -161,9 +184,20 @@ export function createComposeEditor(
   const view = new EditorView(target, {
     state,
     dispatchTransaction(tr: Transaction) {
-      const next = view.state.apply(tr);
+      const prev = view.state;
+      const next = prev.apply(tr);
       view.updateState(next);
       options.onChange(next);
+      // Detect image removals when doc changed and a removal callback exists.
+      if (options.onImageRemoved && tr.docChanged) {
+        const prevSrcs = collectImageSrcs(prev.doc);
+        const nextSrcs = collectImageSrcs(next.doc);
+        for (const src of prevSrcs) {
+          if (!nextSrcs.has(src)) {
+            options.onImageRemoved(src);
+          }
+        }
+      }
     },
   });
   return view;

--- a/web/apps/suite/src/lib/compose/inline-image-issues.test.ts
+++ b/web/apps/suite/src/lib/compose/inline-image-issues.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Tests for issue #83: Inlined image issues.
+ *
+ * Three behaviours under test:
+ *   1. Inline images do NOT appear in the non-inline attachment list —
+ *      only attachments with inline=false count as "file attachments".
+ *   2. Removing an attachment by key revokes its objectURL and drops it
+ *      from compose.attachments (covers the onImageRemoved→removeAttachment
+ *      path exercised by the editor when the user deletes an image node).
+ *   3. collectImageSrcs correctly collects and diffs src attributes across
+ *      ProseMirror document states.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { compose } from './compose.svelte';
+import { collectImageSrcs, htmlToDoc } from './editor';
+
+// Stub the JMAP client so uploadBlob never hits the network.
+vi.mock('../jmap/client', () => ({
+  jmap: {
+    maxUploadSize: null,
+    uploadBlob: vi.fn(),
+    downloadUrl: vi.fn().mockReturnValue(null),
+  },
+  strict: vi.fn(),
+}));
+
+vi.mock('../mail/store.svelte', () => ({
+  mail: {
+    mailAccountId: 'acct1',
+    primaryIdentity: null,
+    drafts: null,
+    identities: new Map(),
+    mailboxes: new Map(),
+    loadMailboxes: vi.fn(),
+    loadIdentities: vi.fn(),
+  },
+}));
+
+vi.mock('../settings/settings.svelte', () => ({
+  settings: { undoWindowSec: 0 },
+}));
+
+vi.mock('../toast/toast.svelte', () => ({
+  toast: { show: vi.fn() },
+}));
+
+vi.mock('../i18n/i18n.svelte', () => ({
+  localeTag: () => 'en',
+}));
+
+// Provide minimal URL stubs so happy-dom does not throw.
+if (typeof globalThis.URL.createObjectURL !== 'function') {
+  let n = 0;
+  globalThis.URL.createObjectURL = () => `blob:test/${++n}`;
+}
+if (typeof globalThis.URL.revokeObjectURL !== 'function') {
+  globalThis.URL.revokeObjectURL = () => undefined;
+}
+
+function makeImageFile(name = 'photo.png'): File {
+  return new File(['img-bytes'], name, { type: 'image/png' });
+}
+
+// ── 1. Inline images do NOT appear in the non-inline attachment list ──────────
+
+describe('inline images omitted from non-inline attachment list (issue #83)', () => {
+  beforeEach(() => {
+    compose.attachments = [];
+    vi.clearAllMocks();
+  });
+
+  it('inline attachment has inline=true and is excluded from non-inline filter', () => {
+    const file = makeImageFile();
+    compose.startInlineImage(file);
+
+    expect(compose.attachments).toHaveLength(1);
+    const att = compose.attachments[0]!;
+    expect(att.inline).toBe(true);
+
+    // The non-inline filter that drives the chip strip must exclude inline images.
+    const nonInline = compose.attachments.filter((a) => !a.inline);
+    expect(nonInline).toHaveLength(0);
+  });
+
+  it('regular file attachment is NOT inline and appears in non-inline filter', async () => {
+    // addAttachments creates a non-inline entry.
+    const file = new File(['data'], 'report.pdf', { type: 'application/pdf' });
+    // We just want to push a ready attachment without network — fake it directly.
+    compose.attachments = [
+      {
+        key: 'att-1',
+        name: 'report.pdf',
+        size: 4,
+        type: 'application/pdf',
+        status: 'ready',
+        blobId: 'blobX',
+        error: null,
+        inline: false,
+      },
+    ];
+
+    const nonInline = compose.attachments.filter((a) => !a.inline);
+    expect(nonInline).toHaveLength(1);
+    expect(nonInline[0]?.name).toBe('report.pdf');
+
+    // No inline attachments.
+    const inlines = compose.attachments.filter((a) => a.inline);
+    expect(inlines).toHaveLength(0);
+
+    void file;
+  });
+
+  it('mixed: only non-inline files appear in attachment chip strip', () => {
+    // Insert one inline image and one regular file.
+    const img = makeImageFile('banner.png');
+    compose.startInlineImage(img);
+    compose.attachments = [
+      ...compose.attachments,
+      {
+        key: 'att-file-1',
+        name: 'document.pdf',
+        size: 100,
+        type: 'application/pdf',
+        status: 'ready',
+        blobId: 'blobY',
+        error: null,
+        inline: false,
+      },
+    ];
+
+    const nonInline = compose.attachments.filter((a) => !a.inline);
+    expect(nonInline).toHaveLength(1);
+    expect(nonInline[0]?.name).toBe('document.pdf');
+  });
+});
+
+// ── 2. removeAttachment drops the record (covers onImageRemoved path) ─────────
+
+describe('removeAttachment removes inline image from compose.attachments (issue #83)', () => {
+  beforeEach(() => {
+    compose.attachments = [];
+    vi.clearAllMocks();
+  });
+
+  it('removeAttachment by key drops the inline attachment record', () => {
+    const file = makeImageFile();
+    const started = compose.startInlineImage(file);
+    expect(started).not.toBeNull();
+    const { key } = started!;
+
+    expect(compose.attachments).toHaveLength(1);
+
+    // This is what the ComposeWindow.onImageRemoved handler calls.
+    compose.removeAttachment(key);
+
+    expect(compose.attachments).toHaveLength(0);
+  });
+
+  it('removeAttachment by key for objectURL-matched inline image removes the record', () => {
+    const file = makeImageFile();
+    const started = compose.startInlineImage(file);
+    expect(started).not.toBeNull();
+    const { key, objectURL } = started!;
+
+    // Simulate the onImageRemoved lookup: find by objectURL, then removeAttachment.
+    const att = compose.attachments.find(
+      (a) => a.inline && a.objectURL === objectURL,
+    );
+    expect(att).toBeTruthy();
+    expect(att?.key).toBe(key);
+
+    compose.removeAttachment(att!.key);
+    expect(compose.attachments).toHaveLength(0);
+  });
+
+  it('removeAttachment by key for cid-matched inline image removes the record', () => {
+    const file = makeImageFile();
+    const started = compose.startInlineImage(file);
+    expect(started).not.toBeNull();
+    const { key, cid } = started!;
+
+    // Simulate the onImageRemoved lookup when src is a cid: URL.
+    const cidSrc = `cid:${cid}`;
+    const att = compose.attachments.find(
+      (a) => a.inline && a.cid && `cid:${a.cid}` === cidSrc,
+    );
+    expect(att).toBeTruthy();
+    expect(att?.key).toBe(key);
+
+    compose.removeAttachment(att!.key);
+    expect(compose.attachments).toHaveLength(0);
+  });
+});
+
+// ── 3. collectImageSrcs diffs document image nodes correctly ─────────────────
+
+describe('collectImageSrcs (issue #83)', () => {
+  it('returns empty set for a document with no images', () => {
+    const doc = htmlToDoc('<p>hello</p>');
+    const srcs = collectImageSrcs(doc);
+    expect(srcs.size).toBe(0);
+  });
+
+  it('collects a single image src', () => {
+    const doc = htmlToDoc('<p><img src="blob:test/1" alt="img"></p>');
+    const srcs = collectImageSrcs(doc);
+    expect(srcs.size).toBe(1);
+    expect(srcs.has('blob:test/1')).toBe(true);
+  });
+
+  it('collects multiple distinct image srcs', () => {
+    const doc = htmlToDoc(
+      '<p><img src="blob:test/1" alt="a"><img src="blob:test/2" alt="b"></p>',
+    );
+    const srcs = collectImageSrcs(doc);
+    expect(srcs.size).toBe(2);
+    expect(srcs.has('blob:test/1')).toBe(true);
+    expect(srcs.has('blob:test/2')).toBe(true);
+  });
+
+  it('correctly identifies a removed src via set difference', () => {
+    const before = htmlToDoc(
+      '<p><img src="blob:test/1" alt="a"><img src="blob:test/2" alt="b"></p>',
+    );
+    const after = htmlToDoc('<p><img src="blob:test/2" alt="b"></p>');
+    const prevSrcs = collectImageSrcs(before);
+    const nextSrcs = collectImageSrcs(after);
+
+    const removed: string[] = [];
+    for (const src of prevSrcs) {
+      if (!nextSrcs.has(src)) removed.push(src);
+    }
+    expect(removed).toEqual(['blob:test/1']);
+  });
+
+  it('reports no removals when the same image is present in both docs', () => {
+    const html = '<p><img src="blob:test/1" alt="a"></p>';
+    const before = htmlToDoc(html);
+    const after = htmlToDoc(html);
+    const prevSrcs = collectImageSrcs(before);
+    const nextSrcs = collectImageSrcs(after);
+
+    const removed: string[] = [];
+    for (const src of prevSrcs) {
+      if (!nextSrcs.has(src)) removed.push(src);
+    }
+    expect(removed).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Inline images no longer appear in the attachment chip strip below the editor — they are already visible in the editor body. The \"Inline\" section has been removed.
- Upload progress for inline images is now visible in the editor itself: images grey out (opacity 0.4 + grayscale 60%) while their JMAP blob upload is in flight.
- Deleting an inline image from the ProseMirror editor (Delete/Backspace/Cut) now removes the corresponding entry from \`compose.attachments\`, preventing stale records from being included in the outbound MIME structure.

Addresses #83.

## Implementation

- **editor.ts**: Added `collectImageSrcs(doc)` and `onImageRemoved` callback to `createComposeEditor`. On each doc-changing transaction, image srcs are diffed; removed srcs trigger the callback.
- **RichEditor.svelte**: Added `onImageRemoved` and `uploadingSrcs` props. A `$effect` applies/removes CSS class `img-uploading` on editor `<img>` nodes whose objectURL is in the uploading set.
- **ComposeWindow.svelte**: Computes `uploadingSrcs` and `nonInlineAttachments` as `$derived` values; passes `onImageRemoved` callback to `RichEditor`; renders only non-inline attachments in the chip strip.
- **ComposeToolbar.svelte**: Migrates from deprecated `addInlineImage` to two-phase `startInlineImage`+`uploadInlineImage` so thumbnails appear immediately.

## Test plan

- [ ] `inline-image-issues.test.ts` — 11 new tests: `collectImageSrcs` diff logic, `removeAttachment` as the `onImageRemoved` backend, non-inline attachment filter.
- [ ] Full vitest suite: 930 tests in 84 files, all green.
- [ ] svelte-check: 0 errors, 0 warnings.
- [ ] Pre-commit hooks: all passed.

Note: puppeteer MCP server was not available in this session; browser-level verification could not be performed. The fix is logic-only with comprehensive unit test coverage. Manual browser verification recommended before merge.

Refs #83.

Generated with [Claude Code](https://claude.com/claude-code)