### PR TITLE
suite(help): fix HelpView 404 by moving bundle out of /manual/ prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,10 @@ coverage.html
 
 # Manual bundle JSON: produced by scripts/build-web.sh and by the
 # bundle-manual scripts in the suite/admin dev loops. Not checked in.
+# Both SPAs now use /help/bundle.json (outside the /manual/ prefix which
+# is reserved for the standalone SSR manual handler).
 /web/apps/suite/public/manual/
+/web/apps/suite/public/help/
 /web/apps/admin/public/manual/
 /web/apps/admin/public/help/
 /web/packages/manual/dist-data/

--- a/scripts/build-web.sh
+++ b/scripts/build-web.sh
@@ -43,11 +43,16 @@ pnpm --dir web install --frozen-lockfile
 MANUAL_MANIFEST="docs/manual/manifest.toml"
 MANUAL_CONTENT="docs/manual"
 MANUAL_BUNDLE_DIR="web/packages/manual/dist-data"
-SUITE_PUBLIC_MANUAL="web/apps/suite/public/manual"
-# The admin SPA fetches the bundle from /admin/help/bundle.json.
-# /admin/manual/ on the admin listener is reserved for the standalone SSR
-# manual (per-chapter HTML pages), so the JSON bundle must live under a
-# different path to avoid the route-collision 404.
+# Both SPAs fetch their bundle from /help/bundle.json (audience-scoped by
+# listener: /help/bundle.json on the public listener for the suite SPA,
+# /admin/help/bundle.json on the admin listener for the admin SPA).
+#
+# /manual/ on the public listener and /admin/manual/ on the admin listener
+# are reserved for the standalone SSR manual handler (per-chapter HTML pages).
+# Go's longest-prefix mux gives those handlers priority over the SPA static
+# file tree, so placing the JSON bundle under /manual/ would yield a 404.
+# Keeping both bundles under /help/ avoids the route-collision entirely.
+SUITE_PUBLIC_HELP="web/apps/suite/public/help"
 ADMIN_PUBLIC_HELP="web/apps/admin/public/help"
 
 echo ">>> bundle manual JSON -> ${MANUAL_BUNDLE_DIR}/"
@@ -62,10 +67,10 @@ if [ ! -f "${MANUAL_BUNDLE_DIR}/user.json" ] || [ ! -f "${MANUAL_BUNDLE_DIR}/adm
   exit 1
 fi
 
-mkdir -p "${SUITE_PUBLIC_MANUAL}" "${ADMIN_PUBLIC_HELP}"
-cp "${MANUAL_BUNDLE_DIR}/user.json"  "${SUITE_PUBLIC_MANUAL}/user.json"
+mkdir -p "${SUITE_PUBLIC_HELP}" "${ADMIN_PUBLIC_HELP}"
+cp "${MANUAL_BUNDLE_DIR}/user.json"  "${SUITE_PUBLIC_HELP}/bundle.json"
 cp "${MANUAL_BUNDLE_DIR}/admin.json" "${ADMIN_PUBLIC_HELP}/bundle.json"
-echo "build-web.sh: manual JSON copied to suite public/manual/ and admin public/help/"
+echo "build-web.sh: manual JSON copied to suite public/help/ and admin public/help/"
 
 # 3. Build the suite SPA. Vite emits to web/apps/suite/dist/.
 echo ">>> pnpm --filter @herold/suite build"

--- a/web/apps/suite/package.json
+++ b/web/apps/suite/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "bundle-manual": "mkdir -p public/manual && node ../../packages/manual/scripts/bundle.mjs --manifest ../../../docs/manual/manifest.toml --content-root ../../../docs/manual --out-json public/manual",
+    "bundle-manual": "node ../../packages/manual/scripts/bundle.mjs --manifest ../../../docs/manual/manifest.toml --content-root ../../../docs/manual --out-json /tmp/herold-suite-bundle && node -e \"require('fs').mkdirSync('public/help',{recursive:true}); require('fs').copyFileSync('/tmp/herold-suite-bundle/user.json','public/help/bundle.json');\"",
     "dev": "pnpm run bundle-manual && vite",
     "build": "vite build",
     "preview": "vite preview",

--- a/web/apps/suite/src/views/HelpView.svelte
+++ b/web/apps/suite/src/views/HelpView.svelte
@@ -28,7 +28,13 @@
 
   onMount(() => {
     loadState = 'loading';
-    fetch('/manual/user.json')
+    // NOTE: /manual/ is reserved on the public listener for the standalone
+    // SSR manual handler (per-chapter HTML), which has longest-prefix priority
+    // over the suite SPA's static file tree.  Fetching from /manual/user.json
+    // would be intercepted and return 404 because the SSR handler does not
+    // serve JSON bundles.  We keep the bundle under /help/bundle.json (outside
+    // the reserved prefix) -- the same pattern used by the admin SPA.
+    fetch('/help/bundle.json')
       .then((res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         return res.json() as Promise<ManualBundle>;

--- a/web/apps/suite/src/views/HelpView.test.ts
+++ b/web/apps/suite/src/views/HelpView.test.ts
@@ -129,6 +129,19 @@ describe('HelpView', () => {
     });
   });
 
+  it('fetches from /help/bundle.json (not /manual/user.json)', async () => {
+    // /manual/ on the public listener is reserved for the standalone SSR manual
+    // handler (longest-prefix priority).  The bundle must live outside that
+    // prefix -- /help/bundle.json -- to avoid a route-collision 404.
+    mockFetch(FIXTURE_BUNDLE);
+    const { default: HelpView } = await import('./HelpView.svelte');
+    render(HelpView);
+
+    await waitFor(() => {
+      expect(globalThis.fetch).toHaveBeenCalledWith('/help/bundle.json');
+    });
+  });
+
   it('shows the loading state before fetch completes', async () => {
     // Never-resolving fetch so the loading state stays visible.
     globalThis.fetch = vi.fn().mockReturnValue(new Promise(() => {}));


### PR DESCRIPTION
## Summary

- Fixes the suite SPA `HelpView` 404 error: the view was fetching `/manual/user.json` for the manual bundle, but `/manual/` on the public listener is mounted for the standalone SSR manual handler (per-chapter HTML) with longest-prefix priority. The SSR handler does not serve JSON bundles, so the fetch returned 404.
- Relocates the suite bundle to `/help/bundle.json` (outside the reserved prefix), matching the pattern already applied to the admin SPA in 6435ff2.
- Updates `scripts/build-web.sh` and the dev-loop `bundle-manual` script in `web/apps/suite/package.json` to copy to the new path. `.gitignore` updated to cover `web/apps/suite/public/help/`.

## Test plan

- [ ] Navigate to the `#/help` route in the suite SPA (against a binary built from this branch) and confirm the user manual renders instead of showing the load-error state.
- Automated: `pnpm --filter @herold/suite test`: 920/920 passed (new assertion: `HelpView > fetches from /help/bundle.json`).
- Automated: `pnpm --filter @herold/suite check`: 0 errors.
- Automated: `pre-commit run --all-files`: all hooks passed.

Note: puppeteer MCP was not available in the agent session. Browser verification of the fix is left to the maintainer per the note in the test plan.

Addresses #58