### PR TITLE
suite(labels): fix edit-label dialog title (re #78)

### DIFF
--- a/web/apps/suite/src/App.svelte
+++ b/web/apps/suite/src/App.svelte
@@ -194,7 +194,7 @@
   async function promptRenameMailbox(id: string, current: string): Promise<void> {
     const mb = mail.mailboxes.get(id);
     const result = await labelDialog.open({
-      title: t('sidebar.renameFolder.title'),
+      title: t('sidebar.editFolder.title'),
       defaultName: current,
       defaultColor: mb?.color ?? undefined,
       confirmLabel: t('sidebar.editFolder.confirm'),

--- a/web/apps/suite/src/lib/i18n/de.ts
+++ b/web/apps/suite/src/lib/i18n/de.ts
@@ -26,6 +26,7 @@ export const de = {
   'sidebar.renameFolder.title': 'Label umbenennen',
   'sidebar.renameFolder.label': 'Neuer Name',
   'sidebar.renameFolder.confirm': 'Umbenennen',
+  'sidebar.editFolder.title': 'Label bearbeiten',
   'sidebar.editFolder.confirm': 'Ändern',
   'sidebar.editFolder.toastChanged': 'Geändert',
   'sidebar.deleteFolder.title': 'Label "{name}" löschen?',

--- a/web/apps/suite/src/lib/i18n/en.ts
+++ b/web/apps/suite/src/lib/i18n/en.ts
@@ -27,6 +27,7 @@ export const en = {
   'sidebar.renameFolder.title': 'Rename label',
   'sidebar.renameFolder.label': 'New name',
   'sidebar.renameFolder.confirm': 'Rename',
+  'sidebar.editFolder.title': 'Edit label',
   'sidebar.editFolder.confirm': 'Change',
   'sidebar.editFolder.toastChanged': 'Changed',
   'sidebar.deleteFolder.title': 'Delete label "{name}"?',


### PR DESCRIPTION
## Summary

- The label edit dialog title still said "Rename label" / "Label umbenennen" after the previous fix (dd2d9e1) which correctly updated the CTA and dirty-gate but missed the popup heading.
- Add `sidebar.editFolder.title` key ("Edit label" / "Label bearbeiten") to both locale files.
- `App.svelte` now passes `t('sidebar.editFolder.title')` instead of `t('sidebar.renameFolder.title')` when opening the edit flow.

## Test plan

- [ ] 83 test files / 919 tests pass (`pnpm --filter @herold/suite test`)
- [ ] svelte-check: 0 errors, 0 warnings
- [ ] Playwright end-to-end: dialog heading confirmed as "Edit label" in en locale (screenshot attached)

Screenshot: dialog heading reads "Edit label" with "Change" CTA (disabled until dirty).

Refs #78