### PR TITLE
imip: fix race in TestIMIP_PersistsCursorOnShutdown

### DIFF
--- a/internal/protojmap/calendars/imip/intake_test.go
+++ b/internal/protojmap/calendars/imip/intake_test.go
@@ -219,13 +219,18 @@ func TestIMIP_PersistsCursorOnShutdown(t *testing.T) {
 	done := make(chan error, 1)
 	go func() { done <- intake.Run(runCtx) }()
 
-	// Drive the worker until it has applied the REQUEST.
-	deadline := time.Now().Add(3 * time.Second)
+	// Drive the worker until BOTH signals are present: the REQUEST has
+	// been applied AND the cursor has advanced. processChange runs
+	// before cursor.Store inside the same tick, so observing only the
+	// store side can race ahead of the cursor write on a slow runner.
+	deadline := time.Now().Add(5 * time.Second)
 	var applied bool
+	var memCursor uint64
 	for time.Now().Before(deadline) {
 		clk.Advance(5 * time.Millisecond)
 		rows, _ := fs.Meta().ListCalendarEvents(ctx, store.CalendarEventFilter{PrincipalID: &p.ID})
-		if len(rows) == 1 {
+		memCursor = intake.Cursor()
+		if len(rows) == 1 && memCursor > 0 {
 			applied = true
 			break
 		}
@@ -234,14 +239,7 @@ func TestIMIP_PersistsCursorOnShutdown(t *testing.T) {
 	if !applied {
 		cancel()
 		<-done
-		t.Fatalf("first intake did not apply the REQUEST")
-	}
-
-	memCursor := intake.Cursor()
-	if memCursor == 0 {
-		cancel()
-		<-done
-		t.Fatalf("first intake's in-memory cursor did not advance")
+		t.Fatalf("first intake did not apply REQUEST and advance cursor (rows=?, cursor=%d)", memCursor)
 	}
 
 	cancel()


### PR DESCRIPTION
## Summary

Same race pattern PR #82 fixed for webpush, hit on PR #84's CI. The test polled `len(rows)==1` and then immediately read `intake.Cursor()`, but `processChange` (which writes the calendar event row) runs inside the for-loop body of `tick` BEFORE `cursor.Store` at the end of `tick`. On a slow runner the test sampled the cursor in the window between the row write and the cursor write, finding it still 0.

Fix: wait for both signals (row count AND cursor advance) in the same loop iteration, with deadline bumped 3s -> 5s.

## Why this keeps happening

This is the third test we've fixed for the same pattern. See follow-up discussion on the parent issue thread — the production code is correct (cursor.Store is the *last* operation in tick, so observing the side effect earlier is racy by definition). A separate PR will land:

1. A `cursortest.WaitForAdvance` helper + documented invariant.
2. Extraction of the defer-flush boilerplate into `cursors.ShutdownFlusher` so future workers don't re-introduce the variant.

## Test plan

- [x] 20x `-race` locally on `TestIMIP_PersistsCursorOnShutdown`

re #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)