### PR TITLE
storefts, queue: defer-based shutdown flush + retry test timeout

### DIFF
--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -465,10 +465,13 @@ func TestRetryExhaustionEmitsFailureDSN(t *testing.T) {
 		Body:       strings.NewReader("Subject: hi\r\n\r\nbody\r\n"),
 		DSNNotify:  store.DSNNotifyFailure,
 	})
-	// Initial attempt + 3 reschedules = 4 total.
+	// Initial attempt + 3 reschedules = 4 total. Per-attempt timeout
+	// bumped to 5s for headroom on slow CI runners; the deliv hook is
+	// synchronous so most iterations resolve well under 100 ms, but
+	// the scheduler poll interval can stretch on contended runners.
 	for i := 0; i < 4; i++ {
 		// Wait for the (i+1)-th call.
-		if !waitFor(t, 2*time.Second, func() bool {
+		if !waitFor(t, 5*time.Second, func() bool {
 			return f.deliv.callCount() >= i+1
 		}) {
 			t.Fatalf("attempt %d never observed", i+1)

--- a/internal/storefts/worker.go
+++ b/internal/storefts/worker.go
@@ -129,6 +129,27 @@ func (w *Worker) Cursor() uint64 {
 	return w.cursor.Load()
 }
 
+// persistCursorOnShutdown writes the in-memory cursor to the durable
+// store and flushes the index using a fresh ctx, so the worker's last
+// advance lands even when the run ctx is already cancelled. Called
+// from Run's defer chain. Persists the cursor BEFORE the index commit:
+// if the cursor write fails we still commit the index, because
+// IndexMessage is idempotent and a small replay on restart is
+// preferable to silently dropping freshly-indexed docs.
+func (w *Worker) persistCursorOnShutdown() {
+	flushCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if seq := w.cursor.Load(); seq > 0 {
+		if err := w.store.Meta().SetFTSCursor(flushCtx, w.opts.CursorKey, seq); err != nil {
+			w.logger.Warn("storefts: persist cursor on shutdown",
+				"key", w.opts.CursorKey,
+				"seq", seq,
+				"err", err.Error())
+		}
+	}
+	_ = w.idx.Commit(flushCtx)
+}
+
 // Lag returns the wall-time delta between now and the ProducedAt of the
 // most recent change indexed. Zero if the worker has never processed a
 // change. Used by the metrics exporter to expose
@@ -154,6 +175,14 @@ func (w *Worker) Run(ctx context.Context) error {
 		return errors.New("storefts: worker already running")
 	}
 	defer w.running.Store(false)
+	// Final flush on shutdown so the in-memory cursor lands on disk
+	// even when the in-loop SetFTSCursor lost its race with ctx
+	// cancellation, and the index commit happens regardless of which
+	// return path Run takes (the loop has multiple early-return paths
+	// — ctx.Err() at the top, ReadChangeFeedForFTS returning canceled,
+	// processBatch returning canceled — and an inline shutdown branch
+	// could be bypassed by any of them).
+	defer w.persistCursorOnShutdown()
 
 	// Hydrate the durable cursor. A missing row returns (0, nil) from
 	// the store, which starts the feed from the beginning; that is the
@@ -170,27 +199,6 @@ func (w *Worker) Run(ctx context.Context) error {
 
 	for {
 		if err := ctx.Err(); err != nil {
-			// Final flush on shutdown so in-flight changes land in the
-			// index AND the durable cursor reflects the in-memory
-			// advance. Use a fresh context so the flush itself is not
-			// cancelled the moment it starts. Persist the cursor
-			// BEFORE the index commit: if the cursor write fails, we
-			// must not commit the index past it (a restart would then
-			// re-read from a stale cursor while the index already
-			// contains the newer docs; IndexMessage is idempotent so
-			// the worst case is a small replay, but we prefer the
-			// invariant that the cursor never trails the index).
-			flushCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			if seq := w.cursor.Load(); seq > 0 {
-				if err := w.store.Meta().SetFTSCursor(flushCtx, w.opts.CursorKey, seq); err != nil {
-					w.logger.Warn("storefts: persist cursor on shutdown",
-						"key", w.opts.CursorKey,
-						"seq", seq,
-						"err", err.Error())
-				}
-			}
-			_ = w.idx.Commit(flushCtx)
-			cancel()
 			return nil
 		}
 		changes, err := w.store.FTS().ReadChangeFeedForFTS(ctx, w.cursor.Load(), w.opts.BatchSize)


### PR DESCRIPTION
## Summary

Two pre-existing CI flakes that were blocking unrelated PRs.

**storefts** — the inline shutdown flush at the top of the `for` loop only fires when `ctx.Err() != nil` is observed by that exact branch. The loop has two other early-return paths (`ReadChangeFeedForFTS → context.Canceled`, `processBatch → context.Canceled`) that bypass the inline branch and return without persisting the cursor. On slow runners where cancel() races with an in-flight tick, the in-memory cursor advance is lost, the next start replays the batch, and the test sees `persisted = 0` even though `final in-memory cursor = 6`.

Convert to a real `defer w.persistCursorOnShutdown()` at the top of `Run`, identical pattern to the other five workers from PR #79 / #81. The fresh-ctx and persist-before-commit invariants are preserved; the only change is that the flush now runs on every return path.

**queue** — `TestRetryExhaustionEmitsFailureDSN` waited 2s per attempt; the scheduler's poll interval can stretch past that on contended runners. Bumped to 5s. Local 10x -race passes.

This is the production-side variant of #91 (extract a shared `ShutdownFlusher`); the long-term cleanup is still the right fix, this is the immediate unblocker.

## Test plan

- [x] 20x `-race` on `./internal/storefts/` (full package, includes the shutdown test) — passes
- [x] 10x `-race` on the queue retry test — passes

re #46 re #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)