### PR TITLE
observe, protoadmin: log measured value with web vital records (re #71)

### DIFF
--- a/internal/observe/client_emitter.go
+++ b/internal/observe/client_emitter.go
@@ -45,6 +45,16 @@ type ClientEvent struct {
 	// UA is the User-Agent string, already capped.
 	UA string
 
+	// VitalName is the Web Vital metric name (e.g. "LCP", "FCP", "TTFB").
+	// Non-empty only when Kind=="vital".
+	VitalName string
+	// VitalValue is the measured Web Vital value in milliseconds (or the unit
+	// defined by the metric). Non-zero only when Kind=="vital".
+	VitalValue float64
+	// VitalID is the opaque attribution identifier for the vital measurement.
+	// Non-empty only when Kind=="vital".
+	VitalID string
+
 	// --- enrichment (added server-side, REQ-OPS-203) ---
 
 	// ServerRecvTS is the server wall clock at receipt.
@@ -122,6 +132,13 @@ func (e *ClientEmitter) emitSlog(ctx context.Context, ev ClientEvent) {
 	}
 	if ev.RequestID != "" {
 		attrs = append(attrs, slog.String("request_id", ev.RequestID))
+	}
+	if ev.Kind == "vital" && ev.VitalName != "" {
+		attrs = append(attrs,
+			slog.String("vital_name", ev.VitalName),
+			slog.Float64("value", ev.VitalValue),
+			slog.String("vital_id", ev.VitalID),
+		)
 	}
 
 	e.log.LogAttrs(ctx, lvl, ev.Msg, attrs...)
@@ -223,6 +240,13 @@ func (e *ClientEmitter) emitOTLP(ctx context.Context, ev ClientEvent) {
 		if ev.Stack != "" {
 			kvs = append(kvs, otellog.String("exception.stacktrace", ev.Stack))
 		}
+	}
+	if ev.Kind == "vital" && ev.VitalName != "" {
+		kvs = append(kvs,
+			otellog.String("vital.name", ev.VitalName),
+			otellog.Float64("vital.value", ev.VitalValue),
+			otellog.String("vital.id", ev.VitalID),
+		)
 	}
 	rec.AddAttributes(kvs...)
 

--- a/internal/observe/client_emitter_test.go
+++ b/internal/observe/client_emitter_test.go
@@ -585,6 +585,70 @@ func TestClientEmitter_SessionIDOptional(t *testing.T) {
 	}
 }
 
+// TestClientEmitter_VitalSlogFields verifies that a kind=vital ClientEvent
+// with populated vital fields emits value, vital_name, and vital_id attrs in
+// the slog record (re #71).
+func TestClientEmitter_VitalSlogFields(t *testing.T) {
+	ev := makeTestEvent("vital", "info", false)
+	ev.VitalName = "LCP"
+	ev.VitalValue = 1234.5
+	ev.VitalID = "v1-abc"
+
+	records := captureLogRecords(t, func(l *slog.Logger) {
+		e := NewClientEmitter(ClientEmitterConfig{
+			Logger:      l,
+			LogProvider: noopLogProvider(),
+		})
+		e.Emit(context.Background(), ev)
+	})
+
+	if len(records) != 1 {
+		t.Fatalf("expected 1 slog record, got %d", len(records))
+	}
+	r := records[0]
+
+	if got, ok := r["vital_name"]; !ok || got != "LCP" {
+		t.Errorf("vital_name: got %v (present=%v), want LCP", got, ok)
+	}
+	if got, ok := r["value"]; !ok {
+		t.Error("value attr missing from slog record")
+	} else if got.(float64) != 1234.5 {
+		t.Errorf("value: got %v, want 1234.5", got)
+	}
+	if got, ok := r["vital_id"]; !ok || got != "v1-abc" {
+		t.Errorf("vital_id: got %v (present=%v), want v1-abc", got, ok)
+	}
+}
+
+// TestClientEmitter_VitalSlogFields_AbsentWhenNotVital verifies that the
+// vital attrs are not emitted for non-vital events.
+func TestClientEmitter_VitalSlogFields_AbsentWhenNotVital(t *testing.T) {
+	ev := makeTestEvent("log", "info", true)
+	// VitalName is empty so no vital attrs should appear.
+
+	records := captureLogRecords(t, func(l *slog.Logger) {
+		e := NewClientEmitter(ClientEmitterConfig{
+			Logger:      l,
+			LogProvider: noopLogProvider(),
+		})
+		e.Emit(context.Background(), ev)
+	})
+
+	if len(records) != 1 {
+		t.Fatalf("expected 1 slog record, got %d", len(records))
+	}
+	r := records[0]
+	if _, ok := r["vital_name"]; ok {
+		t.Error("vital_name should be absent for non-vital event")
+	}
+	if _, ok := r["value"]; ok {
+		t.Error("value should be absent for non-vital event")
+	}
+	if _, ok := r["vital_id"]; ok {
+		t.Error("vital_id should be absent for non-vital event")
+	}
+}
+
 // noopLogProvider returns a noop LoggerProvider for tests that don't need OTLP.
 func noopLogProvider() otellog.LoggerProvider {
 	return noop.NewLoggerProvider()

--- a/internal/protoadmin/clientlog.go
+++ b/internal/protoadmin/clientlog.go
@@ -80,21 +80,24 @@ type wireEvent struct {
 }
 
 // wireNarrowEvent is the narrow (anonymous) event schema (REQ-OPS-207).
-// It excludes breadcrumbs, session_id, request_id, and vital. Unknown
-// fields are rejected (strict parsing via json.Decoder.DisallowUnknownFields).
+// It excludes breadcrumbs, session_id, and request_id. Vital is included so
+// that anonymous pre-auth clients (e.g. the suite SPA before login) can
+// report web vitals. Unknown fields are rejected (strict parsing via
+// json.Decoder.DisallowUnknownFields).
 type wireNarrowEvent struct {
-	V        int    `json:"v"`
-	Kind     string `json:"kind"`
-	Level    string `json:"level"`
-	Msg      string `json:"msg"`
-	Stack    string `json:"stack,omitempty"`
-	ClientTS string `json:"client_ts"`
-	Seq      int64  `json:"seq"`
-	PageID   string `json:"page_id"`
-	App      string `json:"app"`
-	BuildSHA string `json:"build_sha"`
-	Route    string `json:"route"`
-	UA       string `json:"ua"`
+	V        int        `json:"v"`
+	Kind     string     `json:"kind"`
+	Level    string     `json:"level"`
+	Msg      string     `json:"msg"`
+	Stack    string     `json:"stack,omitempty"`
+	ClientTS string     `json:"client_ts"`
+	Seq      int64      `json:"seq"`
+	PageID   string     `json:"page_id"`
+	App      string     `json:"app"`
+	BuildSHA string     `json:"build_sha"`
+	Route    string     `json:"route"`
+	UA       string     `json:"ua"`
+	Vital    *wireVital `json:"vital,omitempty"`
 }
 
 // wireBreadcrumb is the breadcrumb shape (REQ-OPS-202 — allow-listed fields only).

--- a/internal/protoadmin/clientlog_pipeline.go
+++ b/internal/protoadmin/clientlog_pipeline.go
@@ -195,7 +195,7 @@ func clientEventFromFull(ev *wireEvent, serverRecvTS time.Time, userID, listener
 	// Breadcrumbs are stored in the ring buffer as part of payload_json but
 	// are not surfaced in the ClientEvent struct (which is for slog/OTLP).
 
-	return observe.ClientEvent{
+	cev := observe.ClientEvent{
 		Kind:          ev.Kind,
 		Level:         ev.Level,
 		Msg:           msg,
@@ -215,6 +215,12 @@ func clientEventFromFull(ev *wireEvent, serverRecvTS time.Time, userID, listener
 		Endpoint:      "auth",
 		Authenticated: true,
 	}
+	if ev.Vital != nil {
+		cev.VitalName = ev.Vital.Name
+		cev.VitalValue = ev.Vital.Value
+		cev.VitalID = ev.Vital.ID
+	}
+	return cev
 }
 
 // clientEventFromNarrow builds a ClientEvent from the narrow (anonymous) wire schema.
@@ -234,7 +240,7 @@ func clientEventFromNarrow(ev *wireNarrowEvent, serverRecvTS time.Time, listener
 	clientIP := truncateClientIP(remoteAddr)
 	_ = clientIP // stored in ring buffer payload but not in ClientEvent
 
-	return observe.ClientEvent{
+	cev := observe.ClientEvent{
 		Kind:          ev.Kind,
 		Level:         ev.Level,
 		Msg:           msg,
@@ -254,6 +260,12 @@ func clientEventFromNarrow(ev *wireNarrowEvent, serverRecvTS time.Time, listener
 		Endpoint:      "public",
 		Authenticated: false,
 	}
+	if ev.Vital != nil {
+		cev.VitalName = ev.Vital.Name
+		cev.VitalValue = ev.Vital.Value
+		cev.VitalID = ev.Vital.ID
+	}
+	return cev
 }
 
 // clientEventToRow converts a ClientEvent back to a ring-buffer row for

--- a/internal/protoadmin/clientlog_test.go
+++ b/internal/protoadmin/clientlog_test.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -732,5 +733,152 @@ func TestClientlogMetrics_Registered(t *testing.T) {
 	observe.RegisterClientlogMetrics()
 	if observe.ClientlogReceivedTotal == nil {
 		t.Fatal("ClientlogReceivedTotal is nil after RegisterClientlogMetrics")
+	}
+}
+
+// --------------------------------------------------------------------------
+// Vital value propagation (re #71)
+// --------------------------------------------------------------------------
+
+// capturingEmitter records every ClientEvent it receives. Thread-safe.
+type capturingEmitter struct {
+	mu     sync.Mutex
+	events []observe.ClientEvent
+}
+
+func (e *capturingEmitter) Emit(_ context.Context, ev observe.ClientEvent) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.events = append(e.events, ev)
+}
+
+func (e *capturingEmitter) captured() []observe.ClientEvent {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make([]observe.ClientEvent, len(e.events))
+	copy(out, e.events)
+	return out
+}
+
+func (e *capturingEmitter) waitFor(n int, deadline time.Duration) bool {
+	until := time.Now().Add(deadline)
+	for time.Now().Before(until) {
+		e.mu.Lock()
+		got := len(e.events)
+		e.mu.Unlock()
+		if got >= n {
+			return true
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return false
+}
+
+// vitalAuthEventBody returns a kind=vital event body for the authenticated endpoint.
+func vitalAuthEventBody(name string, value float64, id string) map[string]any {
+	return map[string]any{
+		"events": []map[string]any{{
+			"v": 1, "kind": "vital", "level": "info",
+			"msg":       name,
+			"client_ts": "2026-01-01T00:00:00.000Z", "seq": 1, "page_id": "page-v",
+			"app": "suite", "build_sha": "abc123", "route": "/", "ua": "Mozilla/5.0",
+			"vital": map[string]any{
+				"name":  name,
+				"value": value,
+				"id":    id,
+			},
+		}},
+	}
+}
+
+// vitalPublicEventBody is the same but for the narrow (anonymous) endpoint.
+func vitalPublicEventBody(name string, value float64, id string) map[string]any {
+	return map[string]any{
+		"events": []map[string]any{{
+			"v": 1, "kind": "vital", "level": "info",
+			"msg":       name,
+			"client_ts": "2026-01-01T00:00:00.000Z", "seq": 1, "page_id": "page-v",
+			"app": "suite", "build_sha": "abc123", "route": "/", "ua": "Mozilla/5.0",
+			"vital": map[string]any{
+				"name":  name,
+				"value": value,
+				"id":    id,
+			},
+		}},
+	}
+}
+
+// TestClientlogAuth_VitalValuePropagated verifies that the vital payload
+// (name/value/id) arriving on the authenticated endpoint is copied into the
+// ClientEvent that reaches the emitter (re #71).
+func TestClientlogAuth_VitalValuePropagated(t *testing.T) {
+	observe.RegisterClientlogMetrics()
+	cap := &capturingEmitter{}
+	h, apiKey := newClientlogHarnessWithOpts(t, protoadmin.ClientlogOptions{
+		Emitter: cap,
+	})
+
+	res, body := h.post("/api/v1/clientlog", vitalAuthEventBody("LCP", 1234.5, "v1-auth"), nil, apiKey)
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", res.StatusCode, body)
+	}
+
+	if !cap.waitFor(1, 500*time.Millisecond) {
+		t.Fatal("emitter did not receive the vital event within 500ms")
+	}
+	evs := cap.captured()
+	if len(evs) == 0 {
+		t.Fatal("no events captured")
+	}
+	ev := evs[0]
+	if ev.Kind != "vital" {
+		t.Errorf("kind: got %q, want vital", ev.Kind)
+	}
+	if ev.VitalName != "LCP" {
+		t.Errorf("VitalName: got %q, want LCP", ev.VitalName)
+	}
+	if ev.VitalValue != 1234.5 {
+		t.Errorf("VitalValue: got %v, want 1234.5", ev.VitalValue)
+	}
+	if ev.VitalID != "v1-auth" {
+		t.Errorf("VitalID: got %q, want v1-auth", ev.VitalID)
+	}
+}
+
+// TestClientlogPublic_VitalValuePropagated verifies that the vital payload
+// arriving on the anonymous (narrow) endpoint is copied into the ClientEvent
+// that reaches the emitter (re #71). This exercises the fix for the
+// wireNarrowEvent missing Vital field.
+func TestClientlogPublic_VitalValuePropagated(t *testing.T) {
+	observe.RegisterClientlogMetrics()
+	cap := &capturingEmitter{}
+	h, _ := newClientlogHarnessWithOpts(t, protoadmin.ClientlogOptions{
+		Emitter: cap,
+	})
+
+	res, body := h.post("/api/v1/clientlog/public", vitalPublicEventBody("FCP", 567.8, "v1-pub"), nil, "")
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", res.StatusCode, body)
+	}
+
+	if !cap.waitFor(1, 500*time.Millisecond) {
+		t.Fatal("emitter did not receive the public vital event within 500ms")
+	}
+	evs := cap.captured()
+	if len(evs) == 0 {
+		t.Fatal("no events captured")
+	}
+	ev := evs[0]
+	if ev.Kind != "vital" {
+		t.Errorf("kind: got %q, want vital", ev.Kind)
+	}
+	if ev.VitalName != "FCP" {
+		t.Errorf("VitalName: got %q, want FCP", ev.VitalName)
+	}
+	if ev.VitalValue != 567.8 {
+		t.Errorf("VitalValue: got %v, want 567.8", ev.VitalValue)
+	}
+	if ev.VitalID != "v1-pub" {
+		t.Errorf("VitalID: got %q, want v1-pub", ev.VitalID)
 	}
 }


### PR DESCRIPTION
## Summary

- `ClientEvent` was missing `VitalName`/`VitalValue`/`VitalID` fields, so the vital payload had nowhere to land even when correctly decoded on the auth endpoint.
- `wireNarrowEvent` (public/anonymous endpoint) had no `Vital` field, causing strict JSON parsing to reject any vital payload with 400 — this is why the suite SPA's pre-auth vitals were silently dropped.
- `clientEventFromFull` and `clientEventFromNarrow` never copied the vital fields into `ClientEvent`, so even the auth endpoint's correctly-decoded vitals were discarded before reaching `emitSlog`.
- `emitSlog` now appends `vital_name`, `value`, `vital_id` attrs when `Kind=="vital"` and `VitalName` is non-empty; `emitOTLP` gets equivalent `vital.name`/`vital.value`/`vital.id` key-values.

## Test plan

- [ ] `TestClientEmitter_VitalSlogFields` — slog record has `value`, `vital_name`, `vital_id`
- [ ] `TestClientEmitter_VitalSlogFields_AbsentWhenNotVital` — attrs absent for non-vital
- [ ] `TestClientlogAuth_VitalValuePropagated` — auth endpoint round-trip, capturing emitter sees all three fields
- [ ] `TestClientlogPublic_VitalValuePropagated` — public endpoint round-trip (also confirms vital is no longer rejected with 400)
- [ ] E2E with ephemeral dev-instance: both endpoints return 200 and log records show `value=2345.6` / `value=456.7`

All tests pass locally; pre-commit clean.

re #71