### PR TITLE
ci: route arm64 test matrix to self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
 
   test:
     name: test (arm64 / ${{ matrix.store }})
-    runs-on: ubuntu-24.04-arm
+    runs-on: [self-hosted, arm64]
     timeout-minutes: 30
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

The test matrix (sqlite + postgres lanes) ran on the GitHub-hosted `ubuntu-24.04-arm` runner. The maintainer has set up a self-hosted arm64 runner (`self-hosted, arm64`) with Docker installed for the postgres service container. Targeting it eliminates GitHub-hosted minute spend for these two long lanes and gives a stable runner profile.

Other workflow jobs stay on `ubuntu-latest` until the self-hosted runner has spare capacity.

## Pre-reqs (on the runner)

- `docker.io` with the runner user in the docker group (needed for the postgres:16 service container)
- `git`, `curl`, `ca-certificates`, `build-essential`
- Go / Node / pnpm / Python self-install via the respective `setup-*` actions

## First-run validation

The first push that hits CI after merge is the integration test for the runner. If anything is missing, the test (arm64 / *) job will fail and the error message will be specific (`docker: command not found`, `cc: not found`, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)